### PR TITLE
Fix DHCP assigned IP binding not  work

### DIFF
--- a/chart/templates/configmap-dhcp.yaml
+++ b/chart/templates/configmap-dhcp.yaml
@@ -48,7 +48,7 @@ data:
     dhcp-option=67,http://{{ "{{ .SelfIP }}" }}/ztp/ztp.json
     {{ "{{ end }}" }}
 
-    conf-file={{ "{{ .HostIpBindingsConfigPath }}" }}
+    dhcp-hostsfile={{ "{{ .HostIpBindingsConfigPath }}" }}
 
     # Additional options
     # Disable DNS server functionality

--- a/pkg/subnet/dhcpserver/config.go
+++ b/pkg/subnet/dhcpserver/config.go
@@ -276,10 +276,10 @@ func (s *dhcpServer) UpdateDhcpBindings() error {
 	var finalLines []string
 	for ip, item := range s.currentManualBindingClients {
 		s.log.Debugf("adding new dhcp-host binding for IP %s, MAC %s", ip, item.MAC)
+		line := fmt.Sprintf("%s,%s", item.MAC, ip)
 		if len(item.Hostname) > 0 {
-			finalLines = append(finalLines, "# hostname "+item.Hostname)
+			line = fmt.Sprintf("%s,%s,%s", item.MAC, ip, item.Hostname)
 		}
-		line := fmt.Sprintf("dhcp-host=%s,%s", item.MAC, ip)
 		finalLines = append(finalLines, line)
 	}
 


### PR DESCRIPTION
Currently, we are experiencing an issue where IP addresses are bound in the subnet, but DHCP still assigns IPs randomly. We discovered that this is because the configuration reload triggered by the HUP signal is not effective.
- conf-file: When a SIGHUP signal is received, the dnsmasq service needs to be restarted to re-read the configuration file contents.
- dhcp-hostsfile: When dnsmasq receives a SIGHUP signal, it will automatically re-read the configuration file contents.

Reference documentation: [dnsmasq](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html)