### PR TITLE
enableDhcpTrustedOnly set it as optional

### DIFF
--- a/chart/crds/topohub.infrastructure.io_subnets.yaml
+++ b/chart/crds/topohub.infrastructure.io_subnets.yaml
@@ -100,7 +100,6 @@ spec:
                     - enabled
                     type: object
                 required:
-                - enableDhcpTrustedOnly
                 - enablePxe
                 - enableZtp
                 - syncRedfishstatus

--- a/pkg/k8s/apis/topohub.infrastructure.io/v1beta1/subnet_types.go
+++ b/pkg/k8s/apis/topohub.infrastructure.io/v1beta1/subnet_types.go
@@ -85,6 +85,7 @@ type FeatureSpec struct {
 
 	// Enable DHCP trusted only mode (dhcp-ignore=tag:!trusted)
 	// +kubebuilder:default=false
+	// +optional
 	EnableDhcpTrustedOnly bool `json:"enableDhcpTrustedOnly"`
 }
 


### PR DESCRIPTION
The frontend currently does not support the enableDhcpTrustedOnly switch,set it as optional.