### PR TITLE
Add session pool to support connection reuse

### DIFF
--- a/.github/workflows/lint-golang.yaml
+++ b/.github/workflows/lint-golang.yaml
@@ -150,6 +150,9 @@ jobs:
       #   run: |
       #     make lint_golang_everything
 
+      - name: Run unit-test
+        run: go test -short -failfast -count=1 -v -gcflags=all=-l ./pkg/... ./cmd/...
+
   # unitest:
   #   needs: filter_changes
   #   if: ${{ needs.filter_changes.outputs.check == 'true' }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+     "go.testFlags": [
+        "-v",
+        "-count=1",
+        "-gcflags=all=-l"
+    ]
+}

--- a/cmd/topohub/main.go
+++ b/cmd/topohub/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	// Initialize logger
 	logLevel := os.Getenv("LOG_LEVEL")
-	log.InitStdoutLogger(logLevel)
+	log.InitStdoutLogger(log.LogLevel(logLevel))
 
 	// start pprof server
 	debug.RunPProf(*pprofAddress, *pprofPort)

--- a/doc/design/session-pool/README.md
+++ b/doc/design/session-pool/README.md
@@ -1,0 +1,169 @@
+# 客户端会话池设计方案
+
+## 背景
+
+项目中会频繁的使用客户端访问远程服务，如 SSH、Redfish 等，如果每次使用都新建一次连接，会导致建立连接数增加，每次都新建Client然后用完就关闭，会影响性能。添加会话池后，可以做到复用连接，减少新建连接的次数，提高性能。
+
+
+## 目标
+
+**关键目标**
+
+- 构建通用会话池，能给所有类型的客户端使用；
+- 会话池中的连接可以复用，减少新建连接的次数；
+- 会话池中的连接可以设置最大活跃时间，超时后会自动关闭；
+- 实现 SSH 和 Redfish 客户端的会话池；
+
+**非关键目标**
+
+- 业务使用会话池访问 SSH 和 Redfish 客户端；
+- 会话池有最大连接数限制；
+- 会话池的整体和重新激活；
+
+
+## 方案
+
+会话池有两个主要元素，一个是池，一个是池中的元素，我们将池定义为 SessionPool，池中元素定义为 Session。
+
+由于 SessionPool 类似于客户端缓存，因此不需要考虑 Pool 的最大连接数限制。也不需要像传统池一样通过队列来管理 Session 的获取和释放，而是通过 Map 来管理 Session。SessionPool 需要支持以下功能：
+- 获取 Session，如果 Session 不存在，则创建一个新的 Session，通过 Session ID 来标识 Session 的唯一性；
+- 刷新 Session，如果 Session 相关的认证信息变化或者 Session 连接超时，通过刷新 Session 来更新客户端连接信息；
+- 定义回收长期没有使用的 Session；
+
+Session 定义了会话的基本信息以及连接，作为与客户端的中间桥梁，维护了客户端的创建、刷新、重连、关闭等操作。其设计需要最大化的考虑复用性。
+
+
+### 获取 Session
+
+这是最常用的方法，通过 Session ID 从 SessionPool 中获取 Session，如果 Session 不存在则创建一个新的 Session。创建 Session 需校验 Session 的有效性，只有有效的 Session 才能被缓存。如果 Session 已存在于 SessionPool 中，在获取 Session 时也需要对 Session 进行校验，校验通过后返回 Session，否则尝试刷新 Session。
+
+```mermaid
+flowchart LR
+    A[获取Session] --> B{Session存在？}
+    B -- 是 --> C{连接配置是否变化？}
+    C -- 是 --> D[刷新Session]
+    D --> E{刷新成功？}
+    E -- 是 --> F{Ping Session成功？}
+    F -- 是 --> G[返回Session]
+    F -- 否 --> H[返回error]
+    E -- 否 --> H
+    C -- 否 --> F
+    B -- 否 --> I[创建Session]
+    I --> J{创建成功？}
+    J -- 是 --> F
+    J -- 否 --> H
+```
+
+
+### 刷新 Session
+
+刷新 Session 用于更新 Session 的连接信息，通常在 Session 的认证信息变化或者连接超时时使用。刷新操作会尝试重新建立连接，并更新 Session 的相关信息。
+
+```mermaid
+flowchart LR
+    A[刷新Session] --> B{Session存在？}
+    B -- 是 --> C{连接配置是否变化？}
+    C -- 否 --> D[刷新Session]
+    D --> E{刷新成功？}
+    E -- 是 --> F{Ping Session成功？}
+    F -- 是 --> G[返回Session]
+    F -- 否 --> H[返回error]
+    E -- 否 --> H
+    C -- 否 --> F
+    B -- 否 --> H
+```
+
+
+### 回收 Session
+
+每个 Session 都有一个字段记录活跃时间，当 Session 被获取或者刷新时，会更新活跃时间。SessionPool 会定时扫描所有 Session，根据活跃时间判断是否需要回收 Session。
+
+
+## 详细设计
+
+### SessionPool
+
+SessionPool 是一个池的抽象接口，范型用于定义 Session 中 Client 的类型，接口函数如下：
+- GetOrCreate - 获取 Session，如果 Session 不存在，则创建一个新的 Session；
+- Refresh - 刷新 Session，如果 Session 相关的认证信息变化或者 Session 连接超时，通过刷新 Session 来更新客户端连接信息；
+
+```golang
+type SessionPool[T any] interface {
+    GetOrCreate(sessionID string, cfg any) (Session[T], error)
+    Refresh(sessionID string, cfg any) (Session[T], error)
+}
+```
+
+框架提供默认的结构体 sessionPoolImpl 实现 SessionPool 接口，sessionPoolImpl 包含一个 Map 来存储 Session，Map 的 Key 为 Session ID，Value 为 Session。定义一个 gc 函数，用于定期扫描 Map 中的 Session，根据活跃时间判断是否需要回收 Session。通过 maxIdleHour 属性来设置 Session 的最大活跃时间，gcIntervalHour 属性来设置 gc 函数的执行间隔。创建 sessionPoolImpl 时，会启动一个 goroutine 来执行 gc 函数。
+
+在 sessionPoolImpl 中维护着一个读写锁来处理并发问题，GetOrCreate 会拆分为 getSession() 和 createSession() 两个内部函数，getSession() 使用写锁，createSession() 使用读锁，Refresh() 和 gc() 中对 Session 缓存的处理也会使用写锁。每个 Session 的操作都使用 Session 自己的锁来处理并发问题。
+
+在用 NewSessionPool() 创建 SessionPool 时，可通过 Options 来设置可选属性，如 maxIdleHour、gcIntervalHour 等。
+
+
+### Session
+
+Session 抽象函数给 SessionPool 使用，范型用于定义 Session 中 Client 的类型，接口函数如下：
+- GetID - 返回 Session 的 ID；
+- GetClient - 返回 Session 中的客户端实例；
+- Ping - 检查 Session 的连接是否可用；
+- CompareAndRefresh - 比较 Session 的配置是否变化，如果变化则刷新 Session，通过锁来保障原子操作；
+- Close - 关闭 Session，释放资源；
+- UpdateLastActiveTime - 更新 Session 的活跃时间；
+- GetLastActiveTime - 返回 Session 的活跃时间；
+
+```golang
+type Session[T any] interface {
+    GetID() string
+    GetClient() T
+    Ping() error
+    CompareAndRefresh(cfg any, force bool) (bool, error)
+    Close() error
+    UpdateLastActiveTime(t time.Time)
+    GetLastActiveTime() time.Time
+}
+```
+
+框架提供默认的结构体 sessionImpl 实现 Session 接口，sessionImpl 将大多通用逻辑和锁的使用方式都实现了，将不通用的逻辑再抽象为 ClientOperations 接口。业务客户端只需要关注 ClientOperations 接口的实现即可。sessionImpl 的创建函数 newSession() 是 sessionPoolImpl 创建新 Session 时使用的函数。
+```golang
+func newSession[T any](sessionID string, operations ClientOperations[T], cfg any) (Session[T], error)
+```
+
+业务可以通过 SessionPool 先获取 Session，然后再通过 Session 获取 Client 实例。
+```golang
+session, err := pool.GetOrCreate("SESSION-ID", cfg)
+if err != nil {
+    // handle error...
+}
+client := session.GetClient()
+...
+```
+
+
+### ClientOperations
+
+ClientOperations 接口定义了客户端的基本操作，客户端业务开发只需要实现这些描述客户端行为的接口函数，无需关注并发性等复杂问题。范型用于定义 ClientOperations 操作的 Client 的类型，接口函数如下：
+- NewClient - 创建一个新的客户端；
+- Ping - 检查客户端的连接是否可用；
+- Compare - 比较两个客户端的配置是否相同；
+- Refresh - 刷新客户端的配置；
+- Close - 关闭客户端；
+
+```golang
+type ClientOperations[T any] interface {
+    NewClient(cfg any) (T, error)
+    Ping(client T) error
+    Compare(old, new any) bool
+    Refresh(oldClient T, cfg any) (T, error)
+    Close(client T) error
+```
+
+ClientOperations 的实现通过创建 SessionPool 时传递，SessionPool 在创建 Session 时也会将 ClientOperations 传递给 Session。
+```golang
+type MyClientOperations struct {
+    client MyClient
+}
+...
+
+pool := NewSessionPool(ctx, &MyClientOperations{})
+```

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/infrastructure-io/topohub
 go 1.24.4
 
 require (
+	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/grafana/pyroscope-go v1.2.1
 	github.com/onsi/ginkgo/v2 v2.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/agiledragon/gomonkey/v2 v2.13.0 h1:B24Jg6wBI1iB8EFR1c+/aoTg7QN/Cum7YffG8KMIyYo=
+github.com/agiledragon/gomonkey/v2 v2.13.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -51,6 +53,7 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/grafana/pyroscope-go v1.2.1 h1:ewi38pE6XMnoHlZYhGxS3uH5TGKA7vDhkT1T3RVkjq0=
 github.com/grafana/pyroscope-go v1.2.1/go.mod h1:zzT9QXQAp2Iz2ZdS216UiV8y9uXJYQiGE1q8v1FyhqU=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
@@ -61,6 +64,7 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
@@ -113,6 +117,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb2NsU=
 github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6vCBBsiChJQ5U=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -154,6 +160,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
 golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -185,6 +192,7 @@ golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
 golang.org/x/time v0.8.0 h1:9i3RxcPv3PZnitoVGMPDKZSq1xW1gK1Xy3ArNOGZfEg=
 golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/pkg/clients/pool/fake.go
+++ b/pkg/clients/pool/fake.go
@@ -1,0 +1,124 @@
+package pool
+
+import (
+	"reflect"
+	"time"
+)
+
+type fakeClient struct{}
+
+// Check implantation
+var (
+	_ ClientOperations[*fakeClient] = (*fakeClientOperation)(nil)
+	_ Session[*fakeClient]          = (*fakeSession)(nil)
+)
+
+type fakeSession struct {
+	id             string
+	client         *fakeClient
+	lastActiveTime time.Time
+
+	injectPing              func() error
+	injectCompareAndRefresh func(_cfg any, force bool) (bool, error)
+
+	callTimes     map[string]int
+	wantError     map[string]error
+	wantRefreshed bool
+}
+
+func (s *fakeSession) init() {
+	if s.callTimes == nil {
+		s.callTimes = make(map[string]int)
+	}
+	if s.wantError == nil {
+		s.wantError = make(map[string]error)
+	}
+}
+
+func (s *fakeSession) GetID() string {
+	return s.id
+}
+
+func (s *fakeSession) GetClient() *fakeClient {
+	return s.client
+}
+
+func (s *fakeSession) Ping() error {
+	s.init()
+	s.callTimes["Ping"]++
+	if s.injectPing != nil {
+		return s.injectPing()
+	}
+	return s.wantError["Ping"]
+}
+
+func (s *fakeSession) CompareAndRefresh(cfg any, force bool) (bool, error) {
+	s.init()
+	s.callTimes["CompareAndRefresh"]++
+	if s.injectCompareAndRefresh != nil {
+		return s.injectCompareAndRefresh(cfg, force)
+	}
+	return force || s.wantRefreshed, s.wantError["CompareAndRefresh"]
+}
+
+func (s *fakeSession) Close() error {
+	s.init()
+	s.callTimes["Close"]++
+	return s.wantError["Close"]
+}
+
+func (s *fakeSession) UpdateLastActiveTime(t time.Time) {
+	s.lastActiveTime = t
+}
+
+func (s *fakeSession) GetLastActiveTime() time.Time {
+	return s.lastActiveTime
+}
+
+func (s *fakeSession) LastActiveTimeIsAfterMaxIdle(maxIdle time.Duration) bool {
+	return time.Since(s.lastActiveTime) > maxIdle
+}
+
+type fakeClientOperation struct {
+	callTimes map[string]int
+	wantError map[string]error
+}
+
+func (o *fakeClientOperation) init() {
+	if o.callTimes == nil {
+		o.callTimes = make(map[string]int)
+	}
+	if o.wantError == nil {
+		o.wantError = make(map[string]error)
+	}
+}
+
+func (o *fakeClientOperation) NewClient(_cfg any) (*fakeClient, error) {
+	o.init()
+	o.callTimes["NewClient"]++
+	return &fakeClient{}, o.wantError["NewClient"]
+}
+
+func (o *fakeClientOperation) Ping(_c *fakeClient) error {
+	o.init()
+	o.callTimes["Ping"]++
+	return o.wantError["Ping"]
+}
+
+func (o *fakeClientOperation) Compare(old, new any) bool {
+	o.init()
+	o.callTimes["Compare"]++
+	return reflect.DeepEqual(old, new)
+}
+
+func (o *fakeClientOperation) Refresh(c *fakeClient, _cfg any) (*fakeClient, error) {
+	o.init()
+	o.callTimes["Refresh"]++
+	return c, o.wantError["Refresh"]
+}
+
+func (o *fakeClientOperation) Close(_c *fakeClient) error {
+	o.init()
+	o.callTimes["Close"]++
+	return o.wantError["Close"]
+}

--- a/pkg/clients/pool/option.go
+++ b/pkg/clients/pool/option.go
@@ -1,0 +1,55 @@
+package pool
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/infrastructure-io/topohub/pkg/log"
+)
+
+const (
+	DefaultMaxIdleHour    int32 = 24
+	DefaultGcIntervalHour int32 = 6
+)
+
+type Options struct {
+	maxIdleHour    int32
+	gcIntervalHour int32
+	logger         *zap.SugaredLogger
+}
+
+func buildOptions(opts ...Option) Options {
+	var o Options
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.maxIdleHour == 0 {
+		o.maxIdleHour = DefaultMaxIdleHour
+	}
+	if o.gcIntervalHour == 0 {
+		o.gcIntervalHour = DefaultGcIntervalHour
+	}
+	if o.logger == nil {
+		o.logger = log.Logger.Named("sessionPool")
+	}
+	return o
+}
+
+type Option func(*Options)
+
+func WithMaxIdleHouer(maxIdleHour int32) Option {
+	return func(opts *Options) {
+		opts.maxIdleHour = maxIdleHour
+	}
+}
+
+func WithGcIntervalHour(gcIntervalHour int32) Option {
+	return func(opts *Options) {
+		opts.gcIntervalHour = gcIntervalHour
+	}
+}
+
+func WithLogger(logger *zap.SugaredLogger) Option {
+	return func(opts *Options) {
+		opts.logger = logger
+	}
+}

--- a/pkg/clients/pool/option_test.go
+++ b/pkg/clients/pool/option_test.go
@@ -1,0 +1,29 @@
+package pool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/infrastructure-io/topohub/pkg/log"
+)
+
+func TestBuildOptions(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		opts := buildOptions()
+		assert.Equal(t, DefaultMaxIdleHour, opts.maxIdleHour)
+		assert.Equal(t, DefaultGcIntervalHour, opts.gcIntervalHour)
+		assert.Equal(t, "sessionPool", opts.logger.Desugar().Name())
+	})
+
+	t.Run("custom value", func(t *testing.T) {
+		opts := buildOptions(
+			WithMaxIdleHouer(5),
+			WithGcIntervalHour(1),
+			WithLogger(log.Logger.Named("custom")),
+		)
+		assert.Equal(t, int32(5), opts.maxIdleHour)
+		assert.Equal(t, int32(1), opts.gcIntervalHour)
+		assert.Equal(t, "custom", opts.logger.Desugar().Name())
+	})
+}

--- a/pkg/clients/pool/pool.go
+++ b/pkg/clients/pool/pool.go
@@ -1,0 +1,181 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+var (
+	ErrSessionNotFound = errors.New("session not found")
+
+	ErrSessionPingFailed = errors.New("session ping failed")
+)
+
+type SessionPool[T any] interface {
+	// GetOrCreate get the session from cache, if not found, create a new one.
+	GetOrCreate(sessionID string, cfg any) (Session[T], error)
+
+	// Refresh refresh the session config.
+	Refresh(sessionID string, cfg any) (Session[T], error)
+}
+
+// NewSessionFunc define the function to create a new session.
+type NewSessionFunc[T any] func(id string, cfg any) (Session[T], error)
+
+// NewSessionPool create a new session pool.
+func NewSessionPool[T any](ctx context.Context, cliops ClientOperations[T], opts ...Option) SessionPool[T] {
+	options := buildOptions(opts...)
+	pool := &sessionPoolImpl[T]{
+		maxIdleHour:    options.maxIdleHour,
+		gcIntervalHour: options.gcIntervalHour,
+		cliops:         cliops,
+		cache:          make(map[string]Session[T]),
+		log:            options.logger,
+	}
+	go pool.gc(ctx)
+	return pool
+}
+
+// Check implantation
+var _ SessionPool[any] = (*sessionPoolImpl[any])(nil)
+
+type sessionPoolImpl[T any] struct {
+	maxIdleHour    int32
+	gcIntervalHour int32
+	cliops         ClientOperations[T]
+	cache          map[string]Session[T]
+	log            *zap.SugaredLogger
+	sync.RWMutex
+}
+
+func (c *sessionPoolImpl[T]) GetOrCreate(sessionID string, cfg any) (Session[T], error) {
+	session, err := c.getSession(sessionID, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if session != nil {
+		return session, nil
+	}
+
+	// No session found, create a new session
+	session, err = c.createSession(sessionID, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return session, nil
+}
+
+func (c *sessionPoolImpl[T]) getSession(sessionID string, cfg any) (Session[T], error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	session, ok := c.cache[sessionID]
+	if !ok || session == nil {
+		return nil, nil
+	}
+	refreshed, err := session.CompareAndRefresh(cfg, false)
+	if err != nil {
+		return nil, fmt.Errorf("refresh session failed when config changed, err: %v", err)
+	}
+	if refreshed {
+		c.log.Infof("the inported session %s config is different, refresh the session", sessionID)
+	}
+	if err := session.Ping(); err != nil {
+		if !refreshed {
+			c.log.Infof("ping found session %s failed, refresh the session", sessionID)
+			if _, err := session.CompareAndRefresh(cfg, true); err != nil {
+				return nil, fmt.Errorf("refresh session failed when ping failed, err: %v", err)
+			}
+			if err := session.Ping(); err != nil {
+				return nil, ErrSessionPingFailed
+			}
+			return session, nil
+		}
+		return nil, ErrSessionPingFailed
+	}
+	return session, nil
+}
+
+func (c *sessionPoolImpl[T]) createSession(sessionID string, cfg any) (Session[T], error) {
+	c.Lock()
+	defer c.Unlock()
+
+	// Double check
+	if session, ok := c.cache[sessionID]; ok {
+		if err := session.Ping(); err != nil {
+			return nil, ErrSessionPingFailed
+		}
+		return session, nil
+	}
+
+	session, err := newSession(sessionID, c.cliops, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create session failed, err: %v", err)
+	}
+	if err := session.Ping(); err != nil {
+		return nil, ErrSessionPingFailed
+	}
+	session.UpdateLastActiveTime(time.Now())
+	c.cache[sessionID] = session
+	return session, nil
+}
+
+func (c *sessionPoolImpl[T]) Refresh(sessionID string, cfg any) (Session[T], error) {
+	c.Lock()
+	defer c.Unlock()
+
+	session := c.cache[sessionID]
+	if session == nil {
+		return nil, ErrSessionNotFound
+	}
+
+	refreshed, err := session.CompareAndRefresh(cfg, false)
+	if err != nil {
+		return nil, fmt.Errorf("refresh session failed, err: %v", err)
+	}
+	if refreshed {
+		c.log.Infof("the session %s config is not changed, skip refresh", sessionID)
+	}
+	if err := session.Ping(); err != nil {
+		return nil, ErrSessionPingFailed
+	}
+	session.UpdateLastActiveTime(time.Now())
+	return session, nil
+}
+
+func (c *sessionPoolImpl[T]) gc(ctx context.Context) {
+	ticker := time.NewTicker(time.Duration(c.gcIntervalHour) * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.cleanup()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// cleanup clean up expired sessions.
+func (c *sessionPoolImpl[T]) cleanup() {
+	for sessionID := range c.cache {
+		session := c.cache[sessionID]
+		if session == nil {
+			continue
+		}
+		if session.LastActiveTimeIsAfterMaxIdle(time.Duration(c.maxIdleHour) * time.Hour) {
+			c.Lock()
+			delete(c.cache, sessionID)
+			if err := session.Close(); err != nil {
+				c.log.Warnf("close session %s failed, err: %v", sessionID, err)
+			}
+			c.Unlock()
+		}
+	}
+}

--- a/pkg/clients/pool/pool_test.go
+++ b/pkg/clients/pool/pool_test.go
@@ -1,0 +1,242 @@
+package pool
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/infrastructure-io/topohub/pkg/log"
+)
+
+func TestSessionPoolImplGetSession(t *testing.T) {
+	const sessionID = "1000"
+	pool := &sessionPoolImpl[*fakeClient]{
+		cache: make(map[string]Session[*fakeClient]),
+		log:   log.Logger,
+	}
+
+	t.Run("no session found", func(t *testing.T) {
+		session, err := pool.getSession(sessionID, nil)
+		require.NoError(t, err)
+		assert.Nil(t, session)
+	})
+
+	t.Run("compare and refresh session failed", func(t *testing.T) {
+		pool.cache[sessionID] = &fakeSession{
+			wantError: map[string]error{
+				"CompareAndRefresh": fmt.Errorf("test error"),
+			},
+		}
+		session, err := pool.getSession(sessionID, nil)
+		require.ErrorContains(t, err, "refresh session failed when config changed")
+		assert.Nil(t, session)
+	})
+
+	t.Run("ping session failed and has refreshed", func(t *testing.T) {
+		pool.cache[sessionID] = &fakeSession{
+			wantRefreshed: true,
+			wantError: map[string]error{
+				"Ping": fmt.Errorf("test error"),
+			},
+		}
+		session, err := pool.getSession(sessionID, nil)
+		require.ErrorIs(t, err, ErrSessionPingFailed)
+		assert.Nil(t, session)
+	})
+
+	t.Run("ping session failed and refresh failed", func(t *testing.T) {
+		pool.cache[sessionID] = &fakeSession{
+			injectCompareAndRefresh: func(_cfg any, force bool) (bool, error) {
+				if force {
+					return false, errors.New("force refresh error")
+				}
+				return false, nil
+			},
+			wantError: map[string]error{
+				"Ping": fmt.Errorf("test error"),
+			},
+		}
+		session, err := pool.getSession(sessionID, nil)
+		require.ErrorContains(t, err, "refresh session failed when ping failed")
+		assert.Nil(t, session)
+	})
+
+	t.Run("ping session failed and refresh successfully and ping session failed again", func(t *testing.T) {
+		fake := &fakeSession{
+			wantError: map[string]error{
+				"Ping": fmt.Errorf("test error"),
+			},
+		}
+		pool.cache[sessionID] = fake
+		_, err := pool.getSession(sessionID, nil)
+		require.ErrorIs(t, err, ErrSessionPingFailed)
+		assert.Equal(t, 2, fake.callTimes["Ping"])
+		assert.Equal(t, 2, fake.callTimes["CompareAndRefresh"])
+	})
+
+	t.Run("ping session failed and refresh successfully and ping session successfully", func(t *testing.T) {
+		var pingTimes int
+		fake := &fakeSession{
+			injectPing: func() error {
+				if pingTimes == 0 {
+					pingTimes++
+					return fmt.Errorf("test error")
+				}
+				return nil
+			},
+		}
+		pool.cache[sessionID] = fake
+		session, err := pool.getSession(sessionID, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, session)
+		assert.Equal(t, 2, fake.callTimes["Ping"])
+		assert.Equal(t, 2, fake.callTimes["CompareAndRefresh"])
+	})
+
+	t.Run("get session successfully", func(t *testing.T) {
+		fake := &fakeSession{}
+		pool.cache[sessionID] = fake
+		session, err := pool.getSession(sessionID, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, session)
+		assert.Equal(t, 1, fake.callTimes["Ping"])
+		assert.Equal(t, 1, fake.callTimes["CompareAndRefresh"])
+	})
+}
+
+func TestSessionPoolImplCreateSession(t *testing.T) {
+	const sessionID = "1000"
+	pool := &sessionPoolImpl[*fakeClient]{
+		cache: make(map[string]Session[*fakeClient]),
+		log:   log.Logger,
+	}
+
+	t.Run("create session failed", func(t *testing.T) {
+		clear(pool.cache)
+		pool.cliops = &fakeClientOperation{
+			wantError: map[string]error{
+				"NewClient": fmt.Errorf("test error"),
+			},
+		}
+		_, err := pool.createSession(sessionID, nil)
+		require.ErrorContains(t, err, "create session failed")
+	})
+
+	t.Run("ping session failed during creating", func(t *testing.T) {
+		clear(pool.cache)
+		pool.cliops = &fakeClientOperation{
+			wantError: map[string]error{
+				"Ping": fmt.Errorf("test error"),
+			},
+		}
+		_, err := pool.createSession(sessionID, nil)
+		require.ErrorIs(t, err, ErrSessionPingFailed)
+	})
+
+	t.Run("create session successfully", func(t *testing.T) {
+		clear(pool.cache)
+		fake := &fakeClientOperation{}
+		pool.cliops = fake
+
+		session, err := pool.createSession(sessionID, nil)
+		require.NoError(t, err)
+		require.NotNil(t, session)
+		assert.Equal(t, sessionID, session.GetID())
+		assert.Equal(t, 1, fake.callTimes["Ping"])
+		assert.Equal(t, 1, fake.callTimes["NewClient"])
+		assert.True(t, session.GetLastActiveTime().Unix() > 0)
+	})
+
+	t.Run("test concurrent call", func(t *testing.T) {
+		clear(pool.cache)
+		fake := &fakeClientOperation{}
+		pool.cliops = fake
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			session, err := pool.createSession(sessionID, nil)
+			require.NoError(t, err)
+			require.NotNil(t, session)
+			assert.True(t, session.GetLastActiveTime().Unix() > 0)
+		}()
+
+		go func() {
+			defer wg.Done()
+			session, err := pool.createSession(sessionID, nil)
+			require.NoError(t, err)
+			require.NotNil(t, session)
+			assert.True(t, session.GetLastActiveTime().Unix() > 0)
+		}()
+
+		wg.Wait()
+		assert.Equal(t, 2, fake.callTimes["Ping"])
+		assert.Equal(t, 1, fake.callTimes["NewClient"])
+	})
+}
+
+func TestSessionPoolImplRefresh(t *testing.T) {
+	const sessionID = "1000"
+	pool := &sessionPoolImpl[*fakeClient]{
+		cache: make(map[string]Session[*fakeClient]),
+		log:   log.Logger,
+	}
+
+	t.Run("compare and refresh session failed", func(t *testing.T) {
+		pool.cache[sessionID] = &fakeSession{
+			wantError: map[string]error{
+				"CompareAndRefresh": fmt.Errorf("test error"),
+			},
+		}
+		_, err := pool.Refresh(sessionID, nil)
+		require.ErrorContains(t, err, "refresh session failed")
+	})
+
+	t.Run("ping session failed", func(t *testing.T) {
+		pool.cache[sessionID] = &fakeSession{
+			wantRefreshed: true,
+			wantError: map[string]error{
+				"Ping": fmt.Errorf("test error"),
+			},
+		}
+		_, err := pool.Refresh(sessionID, nil)
+		require.ErrorIs(t, err, ErrSessionPingFailed)
+	})
+
+	t.Run("refresh session successfully", func(t *testing.T) {
+		pool.cache[sessionID] = &fakeSession{
+			wantRefreshed: true,
+		}
+		session, err := pool.Refresh(sessionID, nil)
+		require.NoError(t, err)
+		require.NotNil(t, session)
+		assert.True(t, session.GetLastActiveTime().Unix() > 0)
+	})
+}
+
+func TestSessionPoolImplClean(t *testing.T) {
+	session001 := &fakeSession{
+		lastActiveTime: time.Now().Add(-2 * time.Hour),
+	}
+	pool := &sessionPoolImpl[*fakeClient]{
+		maxIdleHour: 1,
+		cache: map[string]Session[*fakeClient]{
+			"1000": session001,
+			"1001": &fakeSession{
+				lastActiveTime: time.Now().Add(-50 * time.Minute),
+			},
+		},
+		log: log.Logger,
+	}
+	pool.cleanup()
+	assert.Len(t, pool.cache, 1)
+	assert.NotNil(t, pool.cache["1001"])
+	assert.Equal(t, 1, session001.callTimes["Close"])
+}

--- a/pkg/clients/pool/session.go
+++ b/pkg/clients/pool/session.go
@@ -1,0 +1,156 @@
+package pool
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Session is a item in the pool.
+type Session[T any] interface {
+	// GetID returns the session ID.
+	GetID() string
+
+	// GetClient returns the client.
+	GetClient() T
+
+	// Ping pings the session.
+	Ping() error
+
+	// CompareAndRefresh refreshes the session with the given config.
+	// If the config has not changed and force is false, no refresh will be performed.
+	// Returns whether the session has been refreshed.
+	// Usually after the authentication information or connection information changes,
+	// this method is used to re-establish the connection.
+	CompareAndRefresh(cfg any, force bool) (bool, error)
+
+	// Close closes the session.
+	Close() error
+
+	// UpdateLastActiveTime updates the last active time.
+	UpdateLastActiveTime(t time.Time)
+
+	// GetLastActiveTime returns the last active time.
+	GetLastActiveTime() time.Time
+
+	// LastActiveTimeIsAfterMaxIdle returns true if the last active time is after max idle time.
+	LastActiveTimeIsAfterMaxIdle(maxIdle time.Duration) bool
+}
+
+type ClientOperations[T any] interface {
+	// NewClient creates a new client.
+	NewClient(cfg any) (T, error)
+
+	// Ping pings the client.
+	Ping(client T) error
+
+	// Compare compares the old and new client configurations.
+	// Returns true if they are the same.
+	Compare(old, new any) bool
+
+	// Refresh refreshes the client with the given config, and returns a new client.
+	Refresh(oldClient T, cfg any) (T, error)
+
+	// Close closes the client.
+	Close(client T) error
+}
+
+// newSession creates a new session.
+func newSession[T any](sessionID string, operations ClientOperations[T], cfg any) (Session[T], error) {
+	if sessionID == "" {
+		return nil, fmt.Errorf("session id must not be empty")
+	}
+	if operations == nil {
+		return nil, fmt.Errorf("operations must not be nil")
+	}
+	client, err := operations.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &sessionImpl[T]{
+		id:               sessionID,
+		clientConfig:     cfg,
+		client:           client,
+		ClientOperations: operations,
+	}, nil
+}
+
+// Check implantation
+var _ Session[any] = (*sessionImpl[any])(nil)
+
+type sessionImpl[T any] struct {
+	// id of the session.
+	id string
+
+	// cfg is a configuration for creating the client
+	clientConfig any
+
+	// client represents the actual client, assigned by the NewClient function.
+	client T
+
+	// lastActiveTime is used for the pool to check if the session is expired.
+	// If the session is not active for a long time, it will be closed and removed from the pool.
+	lastActiveTime time.Time
+
+	// ClientOperations provides client-side functions for session operations.
+	ClientOperations[T]
+
+	// Session-level locks
+	sync.RWMutex
+}
+
+func (s *sessionImpl[T]) GetID() string {
+	return s.id
+}
+
+func (s *sessionImpl[T]) GetClient() T {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.client
+}
+
+// Ping pings the client.
+func (s *sessionImpl[T]) Ping() error {
+	return s.ClientOperations.Ping(s.client)
+}
+
+func (s *sessionImpl[T]) CompareAndRefresh(cfg any, force bool) (bool, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if !force && s.Compare(s.clientConfig, cfg) {
+		return false, nil
+	}
+	client, err := s.Refresh(s.client, cfg)
+	if err != nil {
+		return false, err
+	}
+	s.client = client
+	s.clientConfig = cfg
+	return true, nil
+}
+
+func (s *sessionImpl[T]) Close() error {
+	s.Lock()
+	defer s.Unlock()
+	return s.ClientOperations.Close(s.client)
+}
+
+func (s *sessionImpl[T]) UpdateLastActiveTime(t time.Time) {
+	s.Lock()
+	defer s.Unlock()
+	s.lastActiveTime = t
+}
+
+func (s *sessionImpl[T]) LastActiveTimeIsAfterMaxIdle(maxIdle time.Duration) bool {
+	s.RLock()
+	defer s.RUnlock()
+	return time.Since(s.lastActiveTime) > maxIdle
+}
+
+func (s *sessionImpl[T]) GetLastActiveTime() time.Time {
+	s.RLock()
+	defer s.RUnlock()
+	return s.lastActiveTime
+}

--- a/pkg/clients/pool/session_test.go
+++ b/pkg/clients/pool/session_test.go
@@ -1,0 +1,117 @@
+package pool
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSession(t *testing.T) {
+	const (
+		config    = "{}"
+		sessionID = "1000"
+	)
+	cli := &fakeClient{}
+	cases := []struct {
+		name       string
+		sessionID  string
+		operations ClientOperations[*fakeClient]
+		wantErr    string
+	}{
+		{
+			name:    "session id is empty",
+			wantErr: "session id must not be empty",
+		},
+		{
+			name:      "operations is nil",
+			sessionID: sessionID,
+			wantErr:   "operations must not be nil",
+		},
+		{
+			name:      "new client failed",
+			sessionID: sessionID,
+			operations: &fakeClientOperation{
+				wantError: map[string]error{
+					"NewClient": errors.New("new client failed"),
+				},
+			},
+			wantErr: "new client failed",
+		},
+		{
+			name:       "new session successfully",
+			sessionID:  sessionID,
+			operations: &fakeClientOperation{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			session, err := newSession(c.sessionID, c.operations, config)
+			if c.wantErr != "" {
+				require.ErrorContains(t, err, c.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, session)
+				assert.Equal(t, c.sessionID, session.GetID())
+				assert.Equal(t, config, session.(*sessionImpl[*fakeClient]).clientConfig)
+				assert.Equal(t, c.operations, session.(*sessionImpl[*fakeClient]).ClientOperations)
+				assert.Equal(t, cli, session.GetClient())
+			}
+		})
+	}
+}
+
+func TestSessionImplCompareAndRefresh(t *testing.T) {
+	const oldConfig = "{}"
+
+	t.Run("configs are the same and no refresh", func(t *testing.T) {
+		session := &sessionImpl[*fakeClient]{
+			clientConfig:     oldConfig,
+			ClientOperations: &fakeClientOperation{},
+		}
+		ok, err := session.CompareAndRefresh(oldConfig, false)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("configs are the same and force refresh", func(t *testing.T) {
+		cliops := &fakeClientOperation{}
+		session := &sessionImpl[*fakeClient]{
+			clientConfig:     oldConfig,
+			ClientOperations: cliops,
+		}
+		ok, err := session.CompareAndRefresh(oldConfig, true)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, 1, cliops.callTimes["Refresh"])
+	})
+
+	t.Run("configs are different and refresh failed", func(t *testing.T) {
+		cliops := &fakeClientOperation{
+			wantError: map[string]error{
+				"Refresh": errors.New("refresh error"),
+			},
+		}
+		session := &sessionImpl[*fakeClient]{
+			clientConfig:     oldConfig,
+			ClientOperations: cliops,
+		}
+		ok, err := session.CompareAndRefresh("", false)
+		require.ErrorContains(t, err, "refresh error")
+		assert.False(t, ok)
+	})
+
+	t.Run("configs are different and refresh successfully", func(t *testing.T) {
+		cliops := &fakeClientOperation{}
+		session := &sessionImpl[*fakeClient]{
+			clientConfig:     oldConfig,
+			ClientOperations: cliops,
+		}
+		ok, err := session.CompareAndRefresh("", false)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, 1, cliops.callTimes["Refresh"])
+	})
+}

--- a/pkg/clients/redfish/client.go
+++ b/pkg/clients/redfish/client.go
@@ -1,0 +1,38 @@
+package redfish
+
+import (
+	"github.com/stmcginnis/gofish"
+	"github.com/stmcginnis/gofish/redfish"
+	"go.uber.org/zap"
+)
+
+type RefishClient interface {
+	Ping() error
+	Power(string) error
+	GetInfo() (map[string]string, error)
+	GetLog() ([]*redfish.LogEntry, error)
+	GetSystemsLogEntries() ([]*redfish.LogEntry, error)
+	GetManagersLogEntries() ([]*redfish.LogEntry, error)
+	Logout()
+}
+
+// Check implantation
+var _ RefishClient = (*redfishClientImpl)(nil)
+
+type redfishClientImpl struct {
+	client *gofish.APIClient
+	logger *zap.SugaredLogger
+}
+
+func (c *redfishClientImpl) Ping() error {
+	_, err := c.client.Service.Systems()
+	return err
+}
+
+// Logout terminates the session with the Redfish service and releases resources
+func (c *redfishClientImpl) Logout() {
+	if c != nil && c.client != nil {
+		c.logger.Debug("Logging out from Redfish service")
+		c.client.Logout()
+	}
+}

--- a/pkg/clients/redfish/getinfo.go
+++ b/pkg/clients/redfish/getinfo.go
@@ -1,0 +1,412 @@
+package redfish
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/stmcginnis/gofish/redfish"
+)
+
+func setData(result map[string]string, key, value string) {
+	if len(value) == 0 {
+		result[key] = ""
+	} else {
+		result[key] = value
+	}
+}
+
+const (
+	DeviceType_Unknown = "Unknown"
+	DeviceType_GPU     = "GPU"
+	DeviceType_Storage = "STORAGE"
+	DeviceType_NIC     = "NIC"
+)
+
+func (c *redfishClientImpl) GetInfo() (map[string]string, error) {
+
+	result := map[string]string{}
+
+	// Attached the client to service root
+	service := c.client.Service
+
+	// Query the managers for bmc
+	managers, err := service.Managers()
+	if err != nil {
+		c.logger.Errorf("failed to Query the bmc : %+v", err)
+		return nil, err
+	} else if len(managers) == 0 {
+		c.logger.Errorf("failed to get bmc")
+		return nil, fmt.Errorf("failed to get bmc")
+	}
+	c.logger.Debugf("bmc amount: %d", len(managers))
+	// for n, t := range managers {
+	// 	c.logger.Debugf("bmc[%d]: %+v", n, *t)
+	// }
+
+	bmc := managers[0]
+	// bmc info
+	setData(result, "BmcFirmwareVersion", bmc.FirmwareVersion)
+	setData(result, "BmcStatus", string(bmc.Status.Health))
+
+	// Query the computer systems
+	ss, err := service.Systems()
+	if err != nil {
+		c.logger.Errorf("failed to Query the computer systems: %+v", err)
+		return nil, err
+	} else if len(ss) == 0 {
+		c.logger.Errorf("failed to get system")
+		return nil, fmt.Errorf("failed to get system")
+	}
+	c.logger.Debugf("system amount: %d", len(ss))
+	// for n, t := range ss {
+	// 	c.logger.Debugf("systems[%d]: %+v", n, *t)
+	// }
+
+	// for barel metal case,
+	system := ss[0]
+	// basic info
+	setData(result, "BiosVerison", system.BIOSVersion)
+	setData(result, "HostName", system.HostName)
+	setData(result, "Manufacturer", system.Manufacturer)
+	setData(result, "PowerState", string(system.PowerState))
+	setData(result, "SystemStatus", string(system.Status.Health))
+	setData(result, "RedfishVersion", service.RedfishVersion)
+	setData(result, "Vendor", service.Vendor)
+	// get supported reset types
+	joinStr := c.GetSupportedResetTypes(system)
+	setData(result, "SupportedReset", joinStr)
+
+	// cpu info
+	setData(result, "CpuPhysicalCore", fmt.Sprintf("%d", system.ProcessorSummary.Count))
+	setData(result, "CpuLogicalCore", fmt.Sprintf("%d", system.ProcessorSummary.LogicalProcessorCount))
+	setData(result, "CpuModel", system.ProcessorSummary.Model)
+	setData(result, "CpuStatus", string(system.ProcessorSummary.Status.Health))
+	cpus, err := system.Processors()
+	if err != nil {
+		c.logger.Errorf("failed to get processors: %+v", err)
+		return nil, err
+	}
+	c.logger.Debugf("cpus amount: %d", len(cpus))
+	for n, cpu := range cpus {
+		//c.logger.Debugf("Cpu[%d]: %+v", n, cpu)
+		setData(result, fmt.Sprintf("Cpu[%d].Manufacturer", n), string(cpu.Manufacturer))
+		setData(result, fmt.Sprintf("Cpu[%d].ProcessorType", n), string(cpu.ProcessorType))
+		setData(result, fmt.Sprintf("Cpu[%d].Health", n), string(cpu.Status.Health))
+		setData(result, fmt.Sprintf("Cpu[%d].State", n), string(cpu.Status.State))
+		// theses fields is dynamic, so we don't set them
+		//setData(result, fmt.Sprintf("Cpu[%d].TotalCores", n), fmt.Sprintf("%d", cpu.TotalCores))
+		//setData(result, fmt.Sprintf("Cpu[%d].TotalThreads", n), fmt.Sprintf("%d", cpu.TotalThreads))
+		//setData(result, fmt.Sprintf("Cpu[%d].MaxSpeedMHz", n), fmt.Sprintf("%.2f", float64(cpu.MaxSpeedMHz)/1000))
+		//setData(result, fmt.Sprintf("Cpu[%d].Architecture", n), string(cpu.ProcessorArchitecture))
+		//setData(result, fmt.Sprintf("Cpu[%d].Model", n), cpu.Model)
+	}
+
+	// memory info
+	setData(result, "MemoryTotalGiB", fmt.Sprintf("%.0f", system.MemorySummary.TotalSystemMemoryGiB))
+	setData(result, "MemoryStatus", string(system.MemorySummary.Status.Health))
+	mms, err := system.Memory()
+	if err != nil {
+		c.logger.Errorf("failed to get memory: %+v", err)
+		return nil, err
+	}
+	setData(result, "MemoryChipsAccount", fmt.Sprintf("%d", len(mms)))
+	//在内存条不变时，有时数组的顺序的变换，导致 后续 redfishstatus 会做无意义的更新，暂时 取消这些信息
+	for n, mm := range mms {
+		//c.logger.Debugf("Memory[%d]: %+v", n, mm)
+		setData(result, fmt.Sprintf("Memory[%d].Manufacturer", n), string(mm.Manufacturer))
+		setData(result, fmt.Sprintf("Memory[%d].MemoryType", n), string(mm.MemoryType))
+		setData(result, fmt.Sprintf("Memory[%d].MemoryDeviceType", n), string(mm.MemoryDeviceType))
+		setData(result, fmt.Sprintf("Memory[%d].Manufacturer", n), string(mm.Manufacturer))
+		setData(result, fmt.Sprintf("Memory[%d].Model", n), string(mm.Model))
+		setData(result, fmt.Sprintf("Memory[%d].CapacityGiB", n), fmt.Sprintf("%.2f", float64(mm.CapacityMiB)/1024))
+		setData(result, fmt.Sprintf("Memory[%d].Health", n), string(mm.Status.Health))
+		setData(result, fmt.Sprintf("Memory[%d].State", n), string(mm.Status.State))
+		// theses fields is dynamic, so we don't set them
+		//setData(result, fmt.Sprintf("Memory[%d].Name", n), string(mm.Name))
+		//if len(mm.AllowedSpeedsMHz) > 0 {
+		//	setData(result, fmt.Sprintf("Memory[%d].AllowedSpeedsMHz", n), fmt.Sprintf("%d", mm.AllowedSpeedsMHz[0]))
+		//}
+		//setData(result, fmt.Sprintf("Memory[%d].OperatingSpeedMhz", n), fmt.Sprintf("%d", mm.OperatingSpeedMhz))
+	}
+
+	// storage info - try SimpleStorage first, fallback to Storage
+	if err := c.getStorageInfoWithFallback(system, result); err != nil {
+		c.logger.Errorf("failed to get storage info: %+v", err)
+	}
+
+	// network info
+	// interfaces, err := system.NetworkInterfaces()
+	// if err != nil {
+	// 	c.logger.Errorf("failed to get network interfaces: %+v", err)
+	// 	return nil, err
+	// }
+	// for n, item := range interfaces {
+	// 	c.logger.Debugf("NetworkInterfaces[%d]: %+v", n, item.NetworkAdapter())
+
+	// 	adapter, err := item.NetworkAdapter()
+	// 	if err != nil {
+	// 		c.logger.Errorf("failed to get network adapter: %+v", err)
+	// 		return nil, err
+	// 	}
+	// 	setData(result, fmt.Sprintf("NetworkAdapter[%d].Manufacturer", n), adapter.Manufacturer)
+	// 	setData(result, fmt.Sprintf("NetworkAdapter[%d].Model", n), adapter.Model)
+	// 	setData(result, fmt.Sprintf("NetworkAdapter[%d].Name", n), adapter.Name)
+	// 	for m, c := range adapter.Controllers {
+	// 		setData(result, fmt.Sprintf("NetworkAdapter[%d].Controllers[%d].Manufacturer", n, m), c.FirmwarePackageVersion)
+	// 		setData(result, fmt.Sprintf("NetworkAdapter[%d].Controllers[%d].PCIeType", n, m), string(c.PCIeInterface.PCIeType))
+	// 		setData(result, fmt.Sprintf("NetworkAdapter[%d].Controllers[%d].MaxPCIeType", n, m), string(c.PCIeInterface.MaxPCIeType))
+	// 		setData(result, fmt.Sprintf("NetworkAdapter[%d].Controllers[%d].LanesInUse", n, m), string(c.PCIeInterface.LanesInUse))
+	// 		setData(result, fmt.Sprintf("NetworkAdapter[%d].Controllers[%d].MaxLanes", n, m), string(c.PCIeInterface.MaxLanes))
+	// 		setData(result, fmt.Sprintf("NetworkAdapter[%d].Controllers[%d].NetworkPortCount", n, m), string(c.ControllerCapabilities.NetworkPortCount))
+	// 	}
+	// }
+
+	// pcie info
+	cs, err := service.Chassis()
+	if err != nil {
+		c.logger.Errorf("failed to get chassis: %+v", err)
+		if len(cs) == 0 {
+			return nil, fmt.Errorf("failed to get chassis")
+		}
+	}
+
+	c.logger.Debugf("chassis amount: %d", len(cs))
+	for count, chassis := range cs {
+		pcieList, err := chassis.PCIeDevices()
+		if err != nil {
+			c.logger.Errorf("failed to get pcie devices: %+v", err)
+			return nil, err
+		}
+		c.logger.Debugf("chassis[%d] pcie devices amount: %d", count, len(pcieList))
+		if len(pcieList) == 0 {
+			continue
+		}
+
+	LOOP_PCIEDEVICE:
+		for m, item := range pcieList {
+			// c.logger.Debugf("PCIeDevices[%d]: %+v", m, item)
+
+			switch strings.ToLower(item.Description) {
+			case "GPU Device":
+				setData(result, fmt.Sprintf("PCIeDevices[%d].DeviceType", m), DeviceType_GPU)
+			case "NVMeSSD Device":
+				setData(result, fmt.Sprintf("PCIeDevices[%d].DeviceType", m), DeviceType_Storage)
+			case "NIC device":
+				setData(result, fmt.Sprintf("PCIeDevices[%d].DeviceType", m), DeviceType_NIC)
+			default:
+				setData(result, fmt.Sprintf("PCIeDevices[%d].DeviceType", m), DeviceType_Unknown)
+			}
+
+			setData(result, fmt.Sprintf("PCIeDevices[%d].Name", m), item.Name)
+			setData(result, fmt.Sprintf("PCIeDevices[%d].Manufacturer", m), item.Manufacturer)
+			setData(result, fmt.Sprintf("PCIeDevices[%d].Model", m), item.Model)
+			setData(result, fmt.Sprintf("PCIeDevices[%d].Description", m), item.Description)
+			setData(result, fmt.Sprintf("PCIeDevices[%d].FirmwareVersion", m), item.FirmwareVersion)
+			setData(result, fmt.Sprintf("PCIeDevices[%d].PCIeType", m), string(item.PCIeInterface.PCIeType))
+			setData(result, fmt.Sprintf("PCIeDevices[%d].MaxPCIeType", m), string(item.PCIeInterface.MaxPCIeType))
+			setData(result, fmt.Sprintf("PCIeDevices[%d].LanesInUse", m), fmt.Sprintf("%d", item.PCIeInterface.LanesInUse))
+			setData(result, fmt.Sprintf("PCIeDevices[%d].MaxLanes", m), fmt.Sprintf("%d", item.PCIeInterface.MaxLanes))
+			setData(result, fmt.Sprintf("PCIeDevices[%d].Health", m), string(item.Status.Health))
+			setData(result, fmt.Sprintf("PCIeDevices[%d].State", m), string(item.Status.State))
+
+			pfcs, err := item.PCIeFunctions()
+			if err == nil && len(pfcs) > 0 {
+				c.logger.Debugf("pcie devices[%d] functions amount: %d", m, len(pfcs))
+				for n, pfc := range pfcs {
+					c.logger.Debugf("PCIeDevices[%d].PCIeFunctions[%d]: %+v", m, n, pfc)
+					// for network device function
+					ints, err := pfc.EthernetInterfaces()
+					if err == nil && len(ints) > 0 {
+						setData(result, fmt.Sprintf("PCIeDevices[%d].NetworkInterfacePortCount", m), fmt.Sprintf("%d", len(ints)))
+						for t, netint := range ints {
+							c.logger.Debugf("PCIeDevices[%d].PCIeFunctions[%d].EthernetInterfaces[%d]: %+v", m, n, t, netint)
+							setData(result, fmt.Sprintf("PCIeDevices[%d].Functions[%d].EthernetInterfaces[%d].MACAddress", m, n, t), netint.MACAddress)
+							setData(result, fmt.Sprintf("PCIeDevices[%d].Functions[%d].EthernetInterfaces[%d].SpeedGbps", m, n, t), fmt.Sprintf("%.2f", float64(netint.SpeedMbps)/1000))
+							setData(result, fmt.Sprintf("PCIeDevices[%d].Functions[%d].EthernetInterfaces[%d].State", m, n, t), string(netint.Status.State))
+							setData(result, fmt.Sprintf("PCIeDevices[%d].Functions[%d].EthernetInterfaces[%d].Health", m, n, t), string(netint.Status.Health))
+						}
+						continue LOOP_PCIEDEVICE
+					}
+
+					// for storage device function
+					stors, err := pfc.StorageControllers()
+					if err == nil && len(stors) > 0 {
+						setData(result, fmt.Sprintf("PCIeDevices[%d].StorageControllerPortCount", m), fmt.Sprintf("%d", len(stors)))
+						for t, stor := range stors {
+							c.logger.Debugf("PCIeDevices[%d].Functions[%d].StorageControllers[%d]: %+v", m, n, t, stor)
+							setData(result, fmt.Sprintf("PCIeDevices[%d].Functions[%d].StorageControllers[%d].Health", m, n, t), string(stor.Status.Health))
+							setData(result, fmt.Sprintf("PCIeDevices[%d].Functions[%d].StorageControllers[%d].State", m, n, t), string(stor.Status.State))
+						}
+						continue LOOP_PCIEDEVICE
+					}
+				}
+			}
+
+		}
+
+		break
+	}
+
+	// ?? 是否可以取出安装的 os 信息
+
+	return result, nil
+}
+
+type ResetActionInfo struct {
+	Description string `json:"Description"`
+	Id          string `json:"Id"`
+	Name        string `json:"Name"`
+	Parameters  []struct {
+		AllowableValues []string `json:"AllowableValues"`
+		DataType        string   `json:"DataType"`
+		Name            string   `json:"Name"`
+		Required        bool     `json:"Required"`
+	} `json:"Parameters"`
+}
+
+// GetSupportedResetTypes 获取支持的ResetTypes类型
+func (c *redfishClientImpl) GetSupportedResetTypes(system *redfish.ComputerSystem) string {
+	joinStr := ""
+
+	c.logger.Debug("Get reset types from system SupportedResetTypes", "SupportedResetTypes", system.SupportedResetTypes)
+	for _, item := range system.SupportedResetTypes {
+		if len(joinStr) > 0 {
+			joinStr += ","
+		}
+		joinStr += string(item)
+	}
+	if joinStr != "" {
+		return joinStr
+	}
+
+	// 尝试从ResetActionInfo获取
+	resetInfoPath := fmt.Sprintf("/redfish/v1/Systems/%s/ResetActionInfo", system.ID)
+	c.logger.Debugf("Trying to get reset types from ResetActionInfo URL: %s", resetInfoPath)
+	resp, err := c.client.Get(resetInfoPath)
+	if err != nil {
+		c.logger.Errorf("Failed to get ResetActionInfo: %v", err)
+		return ""
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			c.logger.Warnf("failed to close response body: %v", err)
+		}
+	}()
+
+	// 读取并打印原始响应
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Errorf("Failed to get ResetActionInfo: %v", err)
+		return ""
+	}
+	c.logger.Debugf("ResetActionInfo response: %s", string(respBody))
+
+	// 解析JSON
+	var actionInfo ResetActionInfo
+	err = json.Unmarshal(respBody, &actionInfo)
+	if err != nil {
+		c.logger.Errorf("Failed to decode ResetActionInfo: %v", err)
+		return ""
+	}
+
+	// 查找ResetType参数
+	for _, param := range actionInfo.Parameters {
+		if param.Name == "ResetType" {
+			c.logger.Debugf("Found ResetType parameter with values: %v", param.AllowableValues)
+			for _, value := range param.AllowableValues {
+				if len(joinStr) > 0 {
+					joinStr += ","
+				}
+				joinStr += value
+			}
+			return joinStr
+		}
+	}
+
+	return ""
+}
+
+// getStorageInfoWithFallback tries SimpleStorage first, falls back to Storage interface
+// Output format is compatible with SimpleStorage for consistency
+func (c *redfishClientImpl) getStorageInfoWithFallback(system *redfish.ComputerSystem, result map[string]string) error {
+	// Try SimpleStorage first
+	var err error
+	var count int
+	if count, err = c.getSimpleStorageInfo(system, result); err != nil {
+		c.logger.Errorf("Failed to retrieve storage info using SimpleStorage interface: %v", err)
+	}
+	if count > 0 {
+		c.logger.Debugf("Successfully retrieved storage info using SimpleStorage interface")
+		return nil
+	}
+	// Fallback to Storage interface
+	if count, err = c.getStorageInfoAsSimpleStorage(system, result); err != nil {
+		c.logger.Errorf("Both SimpleStorage and Storage interfaces failed: %v", err)
+		return err
+	}
+	if count == 0 {
+		c.logger.Debugf("Both SimpleStorage and Storage interfaces failed: %v", err)
+		return nil
+	}
+	c.logger.Debugf("Successfully retrieved storage info using Storage interface (fallback)")
+	return nil
+}
+
+// getSimpleStorageInfo retrieves storage information using SimpleStorage interface
+func (c *redfishClientImpl) getSimpleStorageInfo(system *redfish.ComputerSystem, result map[string]string) (int, error) {
+	simpleStorages, err := system.SimpleStorages()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get SimpleStorage: %v", err)
+	}
+
+	c.logger.Debugf("SimpleStorage amount: %d", len(simpleStorages))
+	for n, ss := range simpleStorages {
+		// Get device information
+		c.logger.Debugf("SimpleStorage[%d] devices amount: %d", n, len(ss.Devices))
+		for m, device := range ss.Devices {
+			c.logger.Debugf("SimpleStorage[%d].Device[%d]: %+v", n, m, device)
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].Name", n, m), string(device.Name))
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].TotalGiB", n, m), fmt.Sprintf("%.2f", float64(device.CapacityBytes)/(1024*1024*1024)))
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].Manufacturer", n, m), string(device.Manufacturer))
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].Model", n, m), string(device.Model))
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].Health", n, m), string(device.Status.Health))
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].State", n, m), string(device.Status.State))
+		}
+	}
+
+	return len(simpleStorages), nil
+}
+
+// getStorageInfoAsSimpleStorage retrieves storage information using Storage interface
+// but keeps the original Storage format as fallback
+func (c *redfishClientImpl) getStorageInfoAsSimpleStorage(system *redfish.ComputerSystem, result map[string]string) (int, error) {
+	storages, err := system.Storage()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get Storage: %v", err)
+	}
+
+	c.logger.Debugf("Storage amount: %d (fallback from SimpleStorage)", len(storages))
+	for n, st := range storages {
+		// Get drives information
+		drives, err := st.Drives()
+		if err != nil {
+			c.logger.Errorf("failed to get drives for storage[%d]: %+v", n, err)
+			continue
+		}
+
+		c.logger.Debugf("Storage[%d] drives amount: %d", n, len(drives))
+		for m, drive := range drives {
+			c.logger.Debugf("Storage[%d].Device[%d]: %+v", n, m, drive)
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].Name", n, m), string(drive.Name))
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].TotalGiB", n, m), fmt.Sprintf("%.2f", float64(drive.CapacityBytes)/(1024*1024*1024)))
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].Manufacturer", n, m), string(drive.Manufacturer))
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].Model", n, m), string(drive.Model))
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].Health", n, m), string(drive.Status.Health))
+			setData(result, fmt.Sprintf("Storage[%d].Device[%d].State", n, m), string(drive.Status.State))
+		}
+	}
+
+	return len(storages), nil
+}

--- a/pkg/clients/redfish/log.go
+++ b/pkg/clients/redfish/log.go
@@ -1,0 +1,168 @@
+package redfish
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/stmcginnis/gofish/redfish"
+)
+
+// redfish url: /redfish/v1/Systems/Self/LogServices
+func (c *redfishClientImpl) GetLog() ([]*redfish.LogEntry, error) {
+	result := []*redfish.LogEntry{}
+
+	// Attached the client to service root
+	service := c.client.Service
+
+	// Query the computer systems
+	ss, err := service.Systems()
+	if err != nil {
+		c.logger.Errorf("failed to Query the computer systems: %+v", err)
+		return nil, err
+	} else if len(ss) == 0 {
+		c.logger.Errorf("failed to get system")
+		return nil, fmt.Errorf("failed to get system")
+	}
+	c.logger.Debugf("system amount: %d", len(ss))
+	// for n, t := range ss {
+	// 	c.logger.Debugf("systems[%d]: %+v", n, *t)
+	// }
+
+	// for barel metal case,
+	system := ss[0]
+
+	ls, err := system.LogServices()
+	if err != nil {
+		c.logger.Errorf("failed to Query the log services: %+v", err)
+		return nil, err
+	} else if len(ls) == 0 {
+		c.logger.Errorf("failed to get log service")
+		return nil, nil
+	}
+	c.logger.Debugf("log service amount: %d", len(ls))
+	for _, t := range ls {
+		if t.Status.State != "Enabled" {
+			c.logger.Debugf("log service %s is disabled", t.Name)
+			continue
+		}
+
+		entries, err := t.Entries()
+		if err != nil {
+			return nil, err
+		} else if len(entries) > 0 {
+			c.logger.Debugf("log service entries amount: %d", len(entries))
+			result = append(result, entries...)
+		}
+	}
+
+	// Get manager logs and append them to the result
+	managerLogs, err := c.GetManagerLog()
+	if err == nil && len(managerLogs) > 0 {
+		c.logger.Debugf("adding %d manager log entries", len(managerLogs))
+		result = append(result, managerLogs...)
+	}
+
+	return result, nil
+}
+
+// redfish url: /redfish/v1/Managers/Self/LogServices
+func (c *redfishClientImpl) GetManagerLog() ([]*redfish.LogEntry, error) {
+
+	result := []*redfish.LogEntry{}
+
+	// Attached the client to service root
+	service := c.client.Service
+
+	// Query the managers
+	ms, err := service.Managers()
+	if err != nil {
+		c.logger.Errorf("failed to Query the managers: %+v", err)
+		return nil, err
+	} else if len(ms) == 0 {
+		c.logger.Errorf("failed to get manager")
+		return nil, fmt.Errorf("failed to get manager")
+	}
+	c.logger.Debugf("manager amount: %d", len(ms))
+
+	// For management controller case
+	manager := ms[0]
+
+	ls, err := manager.LogServices()
+	if err != nil {
+		c.logger.Errorf("failed to Query the manager log services: %+v", err)
+		return nil, err
+	} else if len(ls) == 0 {
+		c.logger.Errorf("failed to get manager log service")
+		return nil, nil
+	}
+	c.logger.Debugf("manager log service amount: %d", len(ls))
+	for _, t := range ls {
+		if t.Status.State != "Enabled" {
+			c.logger.Debugf("manager log service %s is disabled", t.Name)
+			continue
+		}
+
+		entries, err := t.Entries()
+		if err != nil {
+			c.logger.Warnf("failed to Query the manager log service entries: %+v", err)
+			return nil, err
+		} else if len(entries) > 0 {
+			c.logger.Debugf("manager log service entries amount: %d", len(entries))
+			result = append(result, entries...)
+		}
+	}
+
+	return result, nil
+}
+
+// GetSystemsLogEntries 获取系统日志条目
+func (c *redfishClientImpl) GetSystemsLogEntries() ([]*redfish.LogEntry, error) {
+	result := []*redfish.LogEntry{}
+
+	// Attached the client to service root
+	service := c.client.Service
+
+	// Query the computer systems
+	ss, err := service.Systems()
+	if err != nil {
+		return nil, err
+	} else if len(ss) == 0 {
+		return nil, errors.New("failed to get system")
+	}
+	c.logger.Debugf("system amount: %d", len(ss))
+
+	// for barel metal case,
+	system := ss[0]
+
+	ls, err := system.LogServices()
+	if err != nil {
+		c.logger.Errorf("failed to Query the log services: %+v", err)
+		return nil, err
+	} else if len(ls) == 0 {
+		c.logger.Errorf("failed to get log service")
+		return nil, nil
+	}
+	c.logger.Debugf("log service amount: %d", len(ls))
+	for _, t := range ls {
+		if t.Status.State != "Enabled" {
+			c.logger.Debugf("log service %s is disabled", t.Name)
+			continue
+		}
+
+		entries, err := t.Entries()
+		if err != nil {
+			c.logger.Warnf("failed to Query the log service entries: %+v", err)
+			return nil, err
+		} else if len(entries) > 0 {
+			c.logger.Debugf("log service entries amount: %d", len(entries))
+			result = append(result, entries...)
+		}
+	}
+
+	return result, nil
+}
+
+// GetManagersLogEntries 获取管理器日志条目
+func (c *redfishClientImpl) GetManagersLogEntries() ([]*redfish.LogEntry, error) {
+	return c.GetManagerLog()
+}

--- a/pkg/clients/redfish/power.go
+++ b/pkg/clients/redfish/power.go
@@ -1,0 +1,152 @@
+package redfish
+
+import (
+	"fmt"
+	"strings"
+
+	topohubv1beta1 "github.com/infrastructure-io/topohub/pkg/k8s/apis/topohub.infrastructure.io/v1beta1"
+	"github.com/stmcginnis/gofish/redfish"
+)
+
+// https://github.com/DMTF/Redfish-Tacklebox/blob/main/scripts/rf_power_reset.py
+// post request to systems
+
+func (c *redfishClientImpl) Power(bootCmd string) error {
+	// Attached the client to service root
+	service := c.client.Service
+	// Query the computer systems
+	ss, err := service.Systems()
+	if err != nil {
+		c.logger.Errorf("failed to Query the computer systems: %+v", err)
+		return err
+	}
+	if len(ss) == 0 {
+		c.logger.Errorf("no system found")
+		return fmt.Errorf("no system found")
+	}
+
+	for _, system := range ss {
+		bootOptions, err := system.BootOptions()
+		if err != nil {
+			c.logger.Errorf("failed to get boot options: %+v", err)
+			return err
+		}
+		c.logger.Debugf("system %s, boot options: %+v", system.Name, bootOptions)
+		c.logger.Debugf("system %s, boot : %+v", system.Name, system.Boot)
+		// url: /redfish/v1/Systems/Self/ResetActionInfo
+		resetTypes := c.GetSupportedResetTypes(system)
+		c.logger.Debugf("system %s, supported reset types: %+v", system.Name, resetTypes)
+
+		switch bootCmd {
+		case topohubv1beta1.BootCmdOn:
+			fallthrough
+		case topohubv1beta1.BootCmdForceOn:
+			fallthrough
+		case topohubv1beta1.BootCmdForceOff:
+			fallthrough
+		case topohubv1beta1.BootCmdGracefulShutdown:
+			fallthrough
+		case topohubv1beta1.BootCmdForceRestart:
+			fallthrough
+		case topohubv1beta1.BootCmdGracefulRestart:
+			c.logger.Infof("operation %s for System: %+v \n", bootCmd, system.Name)
+			err = system.Reset(redfish.ResetType(bootCmd))
+
+		case topohubv1beta1.BootCmdResetPxeOnce:
+			// check if the system supports GracefulRestart or ForceRestart
+			if !strings.Contains(resetTypes, string(redfish.GracefulRestartResetType)) && !strings.Contains(resetTypes, string(redfish.ForceRestartResetType)) {
+				return fmt.Errorf("neither GracefulRestart nor ForceRestart is supported by system %s, supported types: %v", system.Name, resetTypes)
+			}
+
+			// https://github.com/stmcginnis/gofish/blob/main/examples/reboot.md
+			// Creates a boot override to pxe once
+			bootOverride := redfish.Boot{
+				// boot from the Pre-Boot EXecution (PXE) environment
+				BootSourceOverrideTarget: redfish.PxeBootSourceOverrideTarget,
+				// boot (one time) to the Boot Source Override Target
+				BootSourceOverrideEnabled: redfish.OnceBootSourceOverrideEnabled,
+				BootSourceOverrideMode:    redfish.UEFIBootSourceOverrideMode,
+			}
+			c.logger.Infof("pxe reboot for System: %+v", system.Name)
+
+			err = c.pxeRebootWithRetry(system, bootOverride, resetTypes)
+			if err != nil {
+				return fmt.Errorf("failed to set boot options: %+v", err)
+			}
+
+		default:
+			c.logger.Errorf("unknown boot cmd: %+v", bootCmd)
+			return fmt.Errorf("unknown boot cmd: %+v", bootCmd)
+		}
+		if err != nil {
+			c.logger.Errorf("failed to operate system %+v: %+v , the host support reset type: %+v\n", system, err, system.SupportedResetTypes)
+			return fmt.Errorf("failed to operate ")
+		}
+	}
+
+	return nil
+}
+
+// Lenovo machine Redifish requires an ETag,when the ETag does not match, it may report an error, so add a retry
+func (c *redfishClientImpl) pxeRebootWithRetry(system *redfish.ComputerSystem, bootOverride redfish.Boot, resetTypes string) error {
+	// Maximum retry attempts
+	maxRetries := 3
+	var lastErr error
+
+	for i := 0; i < maxRetries; i++ {
+		// If this is not the first attempt, refresh the system info to update ETag
+		if i > 0 {
+			c.logger.Infof("Retry attempt %d for setting PXE boot...", i)
+			// Refresh system info to update ETag
+			systems, refreshErr := c.client.Service.Systems()
+			if refreshErr != nil {
+				return fmt.Errorf("failed to refresh system info: %+v", refreshErr)
+			}
+			if len(systems) == 0 {
+				return fmt.Errorf("no systems found during refresh")
+			}
+
+			// find the system with the same ID
+			originalID := system.ID
+			found := false
+			for _, s := range systems {
+				if s.ID == originalID {
+					system = s
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("system %s not found after refresh", originalID)
+			}
+		}
+
+		// set boot options
+		if err := system.SetBoot(bootOverride); err != nil {
+			c.logger.Errorf("Failed to set boot options: %v, will retry", err)
+			lastErr = err
+			continue
+		}
+
+		// restart system
+		var restartType redfish.ResetType
+		if strings.Contains(resetTypes, string(redfish.GracefulRestartResetType)) {
+			restartType = redfish.GracefulRestartResetType
+		} else {
+			restartType = redfish.ForceRestartResetType
+		}
+
+		c.logger.Infof("using %s restart type for System: %s", restartType, system.Name)
+		if err := system.Reset(restartType); err != nil {
+			c.logger.Errorf("Reset failed after setting boot options: %v, will retry", err)
+			lastErr = err
+			continue
+		}
+
+		// If we get here, it means SetBoot and Reset both succeeded
+		return nil
+	}
+
+	return fmt.Errorf("failed to set boot options after %d retries: %+v", maxRetries, lastErr)
+}

--- a/pkg/clients/redfish/session.go
+++ b/pkg/clients/redfish/session.go
@@ -1,0 +1,172 @@
+package redfish
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"reflect"
+	"time"
+
+	"github.com/stmcginnis/gofish"
+	"go.uber.org/zap"
+
+	"github.com/infrastructure-io/topohub/pkg/clients/pool"
+	"github.com/infrastructure-io/topohub/pkg/log"
+)
+
+type RedfishSessionConfig struct {
+	// IPAddr is the IP address of the redfish server, required.
+	IPAddr string
+	// Port is the port of the redfish server. Default is 443 if https is true, otherwise 80.
+	Port int
+	// Https is true if the redfish server uses https. Default is false.
+	Https bool
+	// Username is the username of the redfish server, required.
+	Username string
+	// Password is the password of the redfish server, required.
+	Password string
+}
+
+func (c *RedfishSessionConfig) VerifyAndSetDefault() error {
+	if c.IPAddr == "" {
+		return fmt.Errorf("ip addr must not be empty")
+	}
+	if c.Port == 0 {
+		if c.Https {
+			c.Port = 443
+		} else {
+			c.Port = 80
+		}
+	}
+	if c.Username == "" || c.Password == "" {
+		return fmt.Errorf("username and password must not be empty")
+	}
+	return nil
+}
+
+// NewRedfishClientOperations creates a new redfish client operations.
+// Example for create a redfish client session pool.
+//
+//	pool := pool.NewSessionPool(ctx, NewRedfishClientOperations(nil))
+func NewRedfishClientOperations(logger *zap.SugaredLogger) *RedfishClientOperations {
+	if logger == nil {
+		logger = log.Logger.Named("redfishClientOperations")
+	}
+	return &RedfishClientOperations{
+		log: logger,
+	}
+}
+
+// Check implantation
+var _ pool.ClientOperations[RefishClient] = (*RedfishClientOperations)(nil)
+
+type RedfishClientOperations struct {
+	cfg *RedfishSessionConfig
+	log *zap.SugaredLogger
+}
+
+func (o *RedfishClientOperations) NewClient(cfg any) (RefishClient, error) {
+	redfishCfg, err := verifyRedfishSessionConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	cli, err := newRedfishClient(redfishCfg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("new redfish client failed: %w", err)
+	}
+	o.cfg = redfishCfg
+	return cli, nil
+}
+
+func (o *RedfishClientOperations) Ping(client RefishClient) error {
+	return client.Ping()
+}
+
+func (RedfishClientOperations) Compare(old, new any) bool {
+	return reflect.DeepEqual(old, new)
+}
+
+func (o *RedfishClientOperations) Refresh(oldClient RefishClient, cfg any) (RefishClient, error) {
+	newcli, err := o.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	oldClient.Logout()
+	return newcli, nil
+}
+
+func (RedfishClientOperations) Close(client RefishClient) error {
+	client.Logout()
+	return nil
+}
+
+func verifyRedfishSessionConfig(cfg any) (*RedfishSessionConfig, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("redfish session config must not be nil")
+	}
+	redfishCfg, ok := cfg.(*RedfishSessionConfig)
+	if !ok {
+		return nil, fmt.Errorf("invalid redfish session config")
+	}
+	if err := redfishCfg.VerifyAndSetDefault(); err != nil {
+		return nil, err
+	}
+	return redfishCfg, nil
+}
+
+// newRedfishClient creates a new redfish client
+func newRedfishClient(cfg *RedfishSessionConfig, logger *zap.SugaredLogger) (RefishClient, error) {
+	if logger == nil {
+		logger = log.Logger.Named("redfishClient")
+	}
+	url := url.URL{
+		Host: fmt.Sprintf("%s:%d", cfg.IPAddr, cfg.Port),
+	}
+	if cfg.Https {
+		url.Scheme = "https"
+	} else {
+		url.Scheme = "http"
+	}
+	config := gofish.ClientConfig{
+		Endpoint:         url.String(),
+		Username:         cfg.Username,
+		Password:         cfg.Password,
+		Insecure:         true,
+		ReuseConnections: true,
+		HTTPClient: &http.Client{
+			Transport: customTransport(),
+		},
+	}
+	logger = logger.With(zap.String("endpoint", config.Endpoint))
+	logger.Debugf("create new redfish client for %s", config.Endpoint)
+	client, err := gofish.Connect(config)
+	if err != nil {
+		return nil, fmt.Errorf("connect to redfish server failed, err: %+v", err)
+	}
+	return &redfishClientImpl{
+		logger: logger,
+		client: client,
+	}, nil
+}
+
+// customTransport returns a custom http transport
+func customTransport() *http.Transport {
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	return &http.Transport{
+		Proxy: defaultTransport.Proxy,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return net.DialTimeout(network, addr, 5*time.Second)
+		},
+		MaxIdleConns:          defaultTransport.MaxIdleConns,
+		MaxIdleConnsPerHost:   defaultTransport.MaxIdleConnsPerHost, // max idle connections per host
+		IdleConnTimeout:       defaultTransport.IdleConnTimeout,     // idle connection timeout
+		ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+		TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+}

--- a/pkg/clients/redfish/session_test.go
+++ b/pkg/clients/redfish/session_test.go
@@ -1,0 +1,194 @@
+package redfish
+
+import (
+	"errors"
+	"testing"
+
+	gomonkey "github.com/agiledragon/gomonkey/v2"
+	"github.com/stmcginnis/gofish"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/infrastructure-io/topohub/pkg/log"
+)
+
+func TestRedfishSessionConfigVerifyAndSetDefault(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     *RedfishSessionConfig
+		wantErr string
+		wantCfg *RedfishSessionConfig
+	}{
+		{
+			name:    "empty ip addr",
+			cfg:     &RedfishSessionConfig{},
+			wantErr: "ip addr must not be empty",
+		},
+		{
+			name: "empty username",
+			cfg: &RedfishSessionConfig{
+				IPAddr: "127.0.0.1",
+			},
+			wantErr: "username and password must not be empt",
+		},
+		{
+			name: "empty password",
+			cfg: &RedfishSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Username: "root",
+			},
+			wantErr: "username and password must not be empt",
+		},
+		{
+			name: "verify successful and set default values 1",
+			cfg: &RedfishSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Username: "root",
+				Password: "123456",
+			},
+			wantCfg: &RedfishSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Port:     80,
+				Https:    false,
+				Username: "root",
+				Password: "123456",
+			},
+		},
+		{
+			name: "verify successful and set default values 2",
+			cfg: &RedfishSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Https:    true,
+				Username: "root",
+				Password: "123456",
+			},
+			wantCfg: &RedfishSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Port:     443,
+				Https:    true,
+				Username: "root",
+				Password: "123456",
+			},
+		},
+		{
+			name: "verify successful",
+			cfg: &RedfishSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Port:     8443,
+				Https:    true,
+				Username: "root",
+				Password: "123456",
+			},
+			wantCfg: &RedfishSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Port:     8443,
+				Https:    true,
+				Username: "root",
+				Password: "123456",
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.cfg.VerifyAndSetDefault()
+			if c.wantErr != "" {
+				require.ErrorContains(t, err, c.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.wantCfg, c.cfg)
+		})
+	}
+}
+
+func TestNewRedfishClientOperations(t *testing.T) {
+	t.Run("default logger", func(t *testing.T) {
+		ops := NewRedfishClientOperations(nil)
+		require.NotNil(t, ops)
+		require.NotNil(t, ops.log)
+		assert.Equal(t, "redfishClientOperations", ops.log.Desugar().Name())
+	})
+
+	t.Run("custom logger", func(t *testing.T) {
+		ops := NewRedfishClientOperations(log.Logger.Named("customLogger"))
+		require.NotNil(t, ops)
+		require.NotNil(t, ops.log)
+		assert.Equal(t, "customLogger", ops.log.Desugar().Name())
+	})
+}
+
+func TestVerifyRedfishSessionConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     any
+		wantErr string
+	}{
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: "redfish session config must not be nil",
+		},
+		{
+			name:    "invalid config type",
+			cfg:     RedfishSessionConfig{},
+			wantErr: "invalid redfish session config",
+		},
+		{
+			name: "verify session config successful",
+			cfg: &RedfishSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Username: "root",
+				Password: "123456",
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := verifyRedfishSessionConfig(c.cfg)
+			if c.wantErr != "" {
+				require.ErrorContains(t, err, c.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewRedfishClient(t *testing.T) {
+	cfg := &RedfishSessionConfig{
+		IPAddr:   "127.0.0.1",
+		Https:    true,
+		Port:     8443,
+		Username: "root",
+		Password: "123456",
+	}
+
+	t.Run("Connect redfish failed", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyFuncReturn(gofish.Connect, nil, errors.New("test error"))
+
+		_, err := newRedfishClient(cfg, nil)
+		require.ErrorContains(t, err, "connect to redfish server failed")
+	})
+
+	t.Run("new redfish client successful", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyFunc(gofish.Connect, func(config gofish.ClientConfig,
+		) (c *gofish.APIClient, err error) {
+			assert.Equal(t, "https://127.0.0.1:8443", config.Endpoint)
+			assert.Equal(t, "root", config.Username)
+			assert.Equal(t, "123456", config.Password)
+			assert.True(t, config.Insecure)
+			assert.True(t, config.ReuseConnections)
+			return nil, nil
+		})
+
+		client, err := newRedfishClient(cfg, nil)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+	})
+}

--- a/pkg/clients/redfish/snmp.go
+++ b/pkg/clients/redfish/snmp.go
@@ -1,0 +1,8 @@
+package redfish
+
+// func (c *redfishClientImpl) Reboot(bootCmd BootCmd) error {}
+// special for vendors
+
+func (c *redfishClientImpl) SetSnmp() error {
+	return nil
+}

--- a/pkg/clients/ssh/client.go
+++ b/pkg/clients/ssh/client.go
@@ -1,0 +1,75 @@
+package ssh
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/infrastructure-io/topohub/pkg/log"
+)
+
+type Client interface {
+	// Ping checks if the SSH connection is alive
+	Ping() error
+
+	// Run executes a command on the remote host
+	Run(cmd string) (string, error)
+
+	// Close closes the SSH connection
+	Close() error
+}
+
+// Check implantation
+var _ Client = (*clientImpl)(nil)
+
+func NewClient(ip string, port int, cfg *ssh.ClientConfig) (Client, error) {
+	// Build connection address
+	addr := net.JoinHostPort(ip, strconv.Itoa(int(port)))
+	// Establish SSH connection
+	conn, err := ssh.Dial("tcp", addr, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("dial ssh connection failed, err: %v", err)
+	}
+	return &clientImpl{conn: conn}, nil
+}
+
+type clientImpl struct {
+	conn *ssh.Client
+}
+
+func (c *clientImpl) Ping() error {
+	_, err := c.Run("echo 1")
+	return err
+}
+
+func (c *clientImpl) Run(cmd string) (string, error) {
+	if c.conn == nil {
+		return "", errors.New("conn is nil")
+	}
+	session, err := c.conn.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("new ssh session failed: %w", err)
+	}
+	defer func() {
+		if err := session.Close(); err != nil && err != io.EOF {
+			log.Logger.Errorf("close ssh session failed: %v", err)
+		}
+	}()
+
+	res, err := session.CombinedOutput(cmd)
+	if err != nil {
+		return string(res), err
+	}
+	return string(res), nil
+}
+
+func (c *clientImpl) Close() error {
+	if c.conn == nil {
+		return nil
+	}
+	return c.conn.Close()
+}

--- a/pkg/clients/ssh/session.go
+++ b/pkg/clients/ssh/session.go
@@ -1,0 +1,148 @@
+package ssh
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/infrastructure-io/topohub/pkg/clients/pool"
+	"github.com/infrastructure-io/topohub/pkg/log"
+)
+
+type SSHSessionConfig struct {
+	// IPAddr is the IP address of the ssh server, required.
+	IPAddr string
+	// Port is the port of the ssh server. Default is 22.
+	Port int
+	// Username is the username of the ssh server, required.
+	Username string
+	// Password is the password of the ssh server, required if SSHKeyAuth is false.
+	Password string
+	// SSHKey is the private key of the ssh server, required if SSHKeyAuth is true.
+	SSHKey string
+	// SSHKeyAuth is true if the ssh server uses private key authentication. Default is false.
+	SSHKeyAuth bool
+}
+
+func (c *SSHSessionConfig) VerifyAndSetDefault() error {
+	if c.IPAddr == "" {
+		return fmt.Errorf("ip addr must not be empty")
+	}
+	if c.Port == 0 {
+		c.Port = 22
+	}
+	if c.Username == "" {
+		return fmt.Errorf("username must not be empty")
+	}
+	return nil
+}
+
+func (c *SSHSessionConfig) BuildAuthMethod() (ssh.AuthMethod, error) {
+	var authMethod ssh.AuthMethod
+	switch {
+	case c.SSHKeyAuth && c.SSHKey != "":
+		signer, err := ssh.ParsePrivateKey([]byte(c.SSHKey))
+		if err != nil {
+			return nil, fmt.Errorf("parse private key failed, err: %v", err)
+		}
+		authMethod = ssh.PublicKeys(signer)
+	case c.Password != "":
+		authMethod = ssh.Password(c.Password)
+	default:
+		return nil, fmt.Errorf("no valid authentication method provided")
+	}
+	return authMethod, nil
+}
+
+// NewSSHCLientOperations creates a new ssh client operations.
+// Example for create a ssh client session pool.
+//
+//	pool := pool.NewSessionPool(ctx, NewSSHCLientOperations(nil))
+func NewSSHCLientOperations(logger *zap.SugaredLogger) *SSHCLientOperations {
+	if logger == nil {
+		logger = log.Logger.Named("sshClientOperations")
+	}
+	return &SSHCLientOperations{
+		log: logger,
+	}
+}
+
+// Check implantation
+var _ pool.ClientOperations[Client] = (*SSHCLientOperations)(nil)
+
+type SSHCLientOperations struct {
+	cfg *SSHSessionConfig
+	log *zap.SugaredLogger
+}
+
+func (o *SSHCLientOperations) NewClient(cfg any) (Client, error) {
+	sshCfg, err := verifySSHSessionConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	cli, err := newSSHClient(sshCfg)
+	if err != nil {
+		return nil, err
+	}
+	o.cfg = sshCfg
+	return cli, nil
+}
+
+func (SSHCLientOperations) Ping(client Client) error {
+	return client.Ping()
+}
+
+func (SSHCLientOperations) Compare(old, new any) bool {
+	return reflect.DeepEqual(old, new)
+}
+
+func (o *SSHCLientOperations) Refresh(oldClient Client, cfg any) (Client, error) {
+	newcli, err := o.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := oldClient.Close(); err != nil {
+		o.log.Warnf("close old ssh client failed, err: %v", err)
+	}
+	return newcli, nil
+}
+
+func (SSHCLientOperations) Close(client Client) error {
+	return client.Close()
+}
+
+func verifySSHSessionConfig(cfg any) (*SSHSessionConfig, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("session config must not be nil")
+	}
+	sshCfg, ok := cfg.(*SSHSessionConfig)
+	if !ok {
+		return nil, fmt.Errorf("invalid ssh session config")
+	}
+	if err := sshCfg.VerifyAndSetDefault(); err != nil {
+		return nil, err
+	}
+	return sshCfg, nil
+}
+
+func newSSHClient(cfg *SSHSessionConfig) (Client, error) {
+	authMethod, err := cfg.BuildAuthMethod()
+	if err != nil {
+		return nil, fmt.Errorf("build ssh auth method failed: %w", err)
+	}
+	config := &ssh.ClientConfig{
+		User: cfg.Username,
+		Auth: []ssh.AuthMethod{authMethod},
+		// In production, a more secure method should be used
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+	cli, err := NewClient(cfg.IPAddr, cfg.Port, config)
+	if err != nil {
+		return nil, fmt.Errorf("create ssh client failed: %w", err)
+	}
+	return cli, nil
+}

--- a/pkg/clients/ssh/session_test.go
+++ b/pkg/clients/ssh/session_test.go
@@ -1,0 +1,324 @@
+package ssh
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	gomonkey "github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/infrastructure-io/topohub/pkg/log"
+)
+
+func TestSSHSessionConfigVerifyAndSetDefault(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     *SSHSessionConfig
+		wantErr string
+		wantCfg *SSHSessionConfig
+	}{
+		{
+			name:    "empty ip addr",
+			cfg:     &SSHSessionConfig{},
+			wantErr: "ip addr must not be empty",
+		},
+		{
+			name:    "empty username",
+			cfg:     &SSHSessionConfig{IPAddr: "127.0.0.1"},
+			wantErr: "username must not be empty",
+		},
+		{
+			name:    "verify successful and set default values",
+			cfg:     &SSHSessionConfig{IPAddr: "127.0.0.1", Username: "root"},
+			wantCfg: &SSHSessionConfig{IPAddr: "127.0.0.1", Username: "root", Port: 22},
+		},
+		{
+			name:    "verify successful",
+			cfg:     &SSHSessionConfig{IPAddr: "127.0.0.1", Username: "root", Port: 1022},
+			wantCfg: &SSHSessionConfig{IPAddr: "127.0.0.1", Username: "root", Port: 1022},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.cfg.VerifyAndSetDefault()
+			if c.wantErr != "" {
+				require.ErrorContains(t, err, c.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.wantCfg, c.cfg)
+		})
+	}
+}
+
+func TestSSHSessionConfigBuildAuthMethod(t *testing.T) {
+	t.Run("no valid authentication method provided", func(t *testing.T) {
+		cfg := &SSHSessionConfig{
+			IPAddr:   "127.0.0.1",
+			Port:     22,
+			Username: "root",
+		}
+		_, err := cfg.BuildAuthMethod()
+		require.ErrorContains(t, err, "no valid authentication method provided")
+	})
+
+	t.Run("parse private key failed", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyFuncReturn(ssh.ParsePrivateKey, nil, errors.New("test error"))
+
+		cfg := &SSHSessionConfig{
+			IPAddr:     "127.0.0.1",
+			Port:       22,
+			Username:   "root",
+			SSHKeyAuth: true,
+			SSHKey:     "xxxx",
+		}
+		_, err := cfg.BuildAuthMethod()
+		require.ErrorContains(t, err, "parse private key failed")
+	})
+
+	t.Run("build public key auth method successful", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyFuncReturn(ssh.ParsePrivateKey, &fakeSinger{}, nil)
+
+		cfg := &SSHSessionConfig{
+			IPAddr:     "127.0.0.1",
+			Port:       22,
+			Username:   "root",
+			SSHKeyAuth: true,
+			SSHKey:     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDRa",
+		}
+		authMethod, err := cfg.BuildAuthMethod()
+		require.NoError(t, err)
+		require.NotNil(t, authMethod)
+	})
+
+	t.Run("build password auth method successful", func(t *testing.T) {
+		cfg := &SSHSessionConfig{
+			IPAddr:   "127.0.0.1",
+			Port:     22,
+			Username: "root",
+			Password: "123456",
+		}
+
+		authMethod, err := cfg.BuildAuthMethod()
+		require.NoError(t, err)
+		require.NotNil(t, authMethod)
+	})
+}
+
+func TestNewSSHCLientOperations(t *testing.T) {
+	t.Run("default logger", func(t *testing.T) {
+		ops := NewSSHCLientOperations(nil)
+		require.NotNil(t, ops)
+		require.NotNil(t, ops.log)
+		assert.Equal(t, "sshClientOperations", ops.log.Desugar().Name())
+	})
+
+	t.Run("custom logger", func(t *testing.T) {
+		ops := NewSSHCLientOperations(log.Logger.Named("customLogger"))
+		require.NotNil(t, ops)
+		require.NotNil(t, ops.log)
+		assert.Equal(t, "customLogger", ops.log.Desugar().Name())
+	})
+}
+
+func TestSSHCLientOperationsCompare(t *testing.T) {
+	cases := []struct {
+		name   string
+		newcfg SSHSessionConfig
+		want   bool
+	}{
+		{
+			name: "configs are the same",
+			newcfg: SSHSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Port:     22,
+				Username: "root",
+				Password: "111111",
+			},
+			want: true,
+		},
+		{
+			name: "IP addr was changed",
+			newcfg: SSHSessionConfig{
+				IPAddr:   "1.1.1.1",
+				Port:     22,
+				Username: "root",
+				Password: "111111",
+			},
+			want: false,
+		},
+		{
+			name: "Port was changed",
+			newcfg: SSHSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Port:     1022,
+				Username: "root",
+				Password: "111111",
+			},
+			want: false,
+		},
+		{
+			name: "Username was changed",
+			newcfg: SSHSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Port:     22,
+				Username: "user",
+				Password: "111111",
+			},
+			want: false,
+		},
+		{
+			name: "password was changed",
+			newcfg: SSHSessionConfig{
+				IPAddr:   "127.0.0.1",
+				Port:     22,
+				Username: "root",
+				Password: "123456",
+			},
+			want: false,
+		},
+	}
+
+	oldcfg := SSHSessionConfig{
+		IPAddr:   "127.0.0.1",
+		Port:     22,
+		Username: "root",
+		Password: "111111",
+	}
+	cliops := NewSSHCLientOperations(nil)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b := cliops.Compare(oldcfg, c.newcfg)
+			assert.Equal(t, c.want, b)
+		})
+	}
+}
+
+func TestVerifySSHSessionConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     any
+		wantErr string
+	}{
+		{
+			name:    "empty config",
+			cfg:     nil,
+			wantErr: "session config must not be nil",
+		},
+		{
+			name:    "invalid config type",
+			cfg:     SSHSessionConfig{},
+			wantErr: "invalid ssh session config",
+		},
+		{
+			name:    "verify successful",
+			cfg:     &SSHSessionConfig{IPAddr: "127.0.0.1", Username: "root"},
+			wantErr: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg, err := verifySSHSessionConfig(c.cfg)
+			if c.wantErr != "" {
+				require.ErrorContains(t, err, c.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, cfg)
+		})
+	}
+}
+
+var _ ssh.Signer = (*fakeSinger)(nil)
+
+type fakeSinger struct{}
+
+func (fakeSinger) PublicKey() ssh.PublicKey {
+	return nil
+}
+
+func (fakeSinger) Sign(_rand io.Reader, _data []byte) (*ssh.Signature, error) {
+	return nil, nil
+}
+
+func TestNewSSHClient(t *testing.T) {
+	t.Run("build auth method failed", func(t *testing.T) {
+		sshCfg := &SSHSessionConfig{
+			IPAddr:   "127.0.0.1",
+			Port:     22,
+			Username: "root",
+			Password: "123456",
+		}
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyMethodReturn((*SSHSessionConfig)(nil), "BuildAuthMethod",
+			nil, errors.New("test error"))
+		patches.ApplyFunc(NewClient, func(ip string, port int, cfg *ssh.ClientConfig,
+		) (Client, error) {
+			assert.Equal(t, sshCfg.IPAddr, ip)
+			assert.Equal(t, sshCfg.Port, port)
+			assert.NotNil(t, cfg)
+			assert.Equal(t, sshCfg.Username, cfg.User)
+			assert.Len(t, cfg.Auth, 1)
+			return &clientImpl{}, nil
+		})
+
+		_, err := newSSHClient(sshCfg)
+		require.ErrorContains(t, err, "build ssh auth method failed")
+	})
+
+	t.Run("new client failed", func(t *testing.T) {
+		sshCfg := &SSHSessionConfig{
+			IPAddr:   "127.0.0.1",
+			Port:     22,
+			Username: "root",
+			Password: "123456",
+		}
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyFuncReturn(NewClient, nil, errors.New("test error"))
+
+		_, err := newSSHClient(sshCfg)
+		require.ErrorContains(t, err, "create ssh client failed")
+	})
+
+	t.Run("build auth method failed", func(t *testing.T) {
+		sshCfg := &SSHSessionConfig{
+			IPAddr:   "127.0.0.1",
+			Port:     22,
+			Username: "root",
+			Password: "123456",
+		}
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyFunc(NewClient, func(ip string, port int, cfg *ssh.ClientConfig,
+		) (Client, error) {
+			assert.Equal(t, sshCfg.IPAddr, ip)
+			assert.Equal(t, sshCfg.Port, port)
+			assert.NotNil(t, cfg)
+			assert.Equal(t, sshCfg.Username, cfg.User)
+			assert.Len(t, cfg.Auth, 1)
+			return &clientImpl{}, nil
+		})
+
+		cli, err := newSSHClient(sshCfg)
+		require.NoError(t, err)
+		require.NotNil(t, cli)
+	})
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -5,7 +5,6 @@ package log
 
 import (
 	"fmt"
-	"strings"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -13,19 +12,31 @@ import (
 
 var Logger *zap.SugaredLogger
 
+const (
+	LogLevelDebug LogLevel = "debug"
+	LogLevelInfo  LogLevel = "info"
+	LogLevelError LogLevel = "error"
+)
+
+type LogLevel string
+
+func init() {
+	InitStdoutLogger(LogLevelInfo)
+}
+
 // InitStdoutLogger initializes the global logger with the specified log level
-func InitStdoutLogger(logLevel string) {
+func InitStdoutLogger(logLevel LogLevel) {
 	if logLevel == "" {
-		logLevel = "debug" // default log level
+		logLevel = LogLevelInfo // default log level
 	}
 
 	var level zapcore.Level
-	switch strings.ToLower(logLevel) {
-	case "debug":
+	switch logLevel {
+	case LogLevelDebug:
 		level = zapcore.DebugLevel
-	case "info":
+	case LogLevelInfo:
 		level = zapcore.InfoLevel
-	case "error":
+	case LogLevelError:
 		level = zapcore.ErrorLevel
 	default:
 		level = zapcore.DebugLevel

--- a/vendor/github.com/agiledragon/gomonkey/v2/.gitignore
+++ b/vendor/github.com/agiledragon/gomonkey/v2/.gitignore
@@ -1,0 +1,6 @@
+.*
+!.gitignore
+!.github
+
+coverage.*
+profile.out

--- a/vendor/github.com/agiledragon/gomonkey/v2/LICENSE
+++ b/vendor/github.com/agiledragon/gomonkey/v2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Zhang Xiaolong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/agiledragon/gomonkey/v2/Makefile
+++ b/vendor/github.com/agiledragon/gomonkey/v2/Makefile
@@ -1,0 +1,4 @@
+test:
+	bash ./ut.sh
+
+.PHONY: test

--- a/vendor/github.com/agiledragon/gomonkey/v2/README.md
+++ b/vendor/github.com/agiledragon/gomonkey/v2/README.md
@@ -1,0 +1,55 @@
+# gomonkey
+
+gomonkey is a library to make monkey patching in unit tests easy, and the core idea of monkey patching comes from [Bouke](https://github.com/bouk), you can read [this blogpost](https://bou.ke/blog/monkey-patching-in-go/) for an explanation on how it works.
+
+## Features
+
++ support a patch for a function
++ support a patch for a public member method
++ support a patch for a private member method
++ support a patch for a interface
++ support a patch for a function variable
++ support a patch for a global variable
++ support patches of a specified sequence for a function
++ support patches of a specified sequence for a member method
++ support patches of a specified sequence for a interface
++ support patches of a specified sequence for a function variable
+
+## Notes
++ gomonkey fails to patch a function or a member method if inlining is enabled, please running your tests with inlining disabled by adding the command line argument that is `-gcflags=-l`(below go1.10) or `-gcflags=all=-l`(go1.10 and above).
++ A panic may happen when a goroutine is patching a function or a member method that is visited by another goroutine at the same time. That is to say, gomonkey is not threadsafe.
+
+## Supported Platform:
+
+- ARCH
+  - amd64
+  - arm64
+  - 386
+  - loong64
+  - riscv64
+
+- OS
+  - Linux
+  - MAC OS X
+  - Windows
+
+## Installation
+- below v2.1.0, for example v2.0.2
+```go
+$ go get github.com/agiledragon/gomonkey@v2.0.2
+```
+- v2.1.0 and above, for example v2.11.0
+```go
+$ go get github.com/agiledragon/gomonkey/v2@v2.11.0
+```
+
+## Test Method
+```go
+$ cd test 
+$ go test -gcflags=all=-l
+```
+
+## Using gomonkey
+
+Please refer to the test cases as idioms, very complete and detailed.
+

--- a/vendor/github.com/agiledragon/gomonkey/v2/creflect/ae1.17.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/creflect/ae1.17.go
@@ -1,0 +1,39 @@
+//go:build go1.17
+// +build go1.17
+
+package creflect
+
+import (
+	"unsafe"
+)
+
+// name is an encoded type name with optional extra data.
+type name struct {
+	bytes *byte
+}
+
+func (n name) data(off int, whySafe string) *byte {
+	return (*byte)(add(unsafe.Pointer(n.bytes), uintptr(off), whySafe))
+}
+
+func (n name) readVarint(off int) (int, int) {
+	v := 0
+	for i := 0; ; i++ {
+		x := *n.data(off+i, "read varint")
+		v += int(x&0x7f) << (7 * i)
+		if x&0x80 == 0 {
+			return i + 1, v
+		}
+	}
+}
+
+func (n name) name() (s string) {
+	if n.bytes == nil {
+		return
+	}
+	i, l := n.readVarint(1)
+	hdr := (*String)(unsafe.Pointer(&s))
+	hdr.Data = unsafe.Pointer(n.data(1+i, "non-empty string"))
+	hdr.Len = l
+	return
+}

--- a/vendor/github.com/agiledragon/gomonkey/v2/creflect/be1.16.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/creflect/be1.16.go
@@ -1,0 +1,25 @@
+//go:build !go1.17
+// +build !go1.17
+
+package creflect
+
+import (
+	"unsafe"
+)
+
+// name is an encoded type name with optional extra data.
+type name struct {
+	bytes *byte
+}
+
+func (n name) name() (s string) {
+	if n.bytes == nil {
+		return
+	}
+	b := (*[4]byte)(unsafe.Pointer(n.bytes))
+
+	hdr := (*String)(unsafe.Pointer(&s))
+	hdr.Data = unsafe.Pointer(&b[3])
+	hdr.Len = int(b[1])<<8 | int(b[2])
+	return s
+}

--- a/vendor/github.com/agiledragon/gomonkey/v2/creflect/type.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/creflect/type.go
@@ -1,0 +1,179 @@
+// Customized reflect package for gomonkey，copy most code from go/src/reflect/type.go
+
+package creflect
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// rtype is the common implementation of most values.
+// rtype must be kept in sync with ../runtime/type.go:/^type._type.
+type rtype struct {
+	size       uintptr
+	ptrdata    uintptr // number of bytes in the type that can contain pointers
+	hash       uint32  // hash of type; avoids computation in hash tables
+	tflag      tflag   // extra type information flags
+	align      uint8   // alignment of variable with this type
+	fieldAlign uint8   // alignment of struct field with this type
+	kind       uint8   // enumeration for C
+	// function for comparing objects of this type
+	// (ptr to object A, ptr to object B) -> ==?
+	equal     func(unsafe.Pointer, unsafe.Pointer) bool
+	gcdata    *byte   // garbage collection data
+	str       nameOff // string form
+	ptrToThis typeOff // type for pointer to this type, may be zero
+}
+
+func Create(t reflect.Type) *rtype {
+	i := *(*funcValue)(unsafe.Pointer(&t))
+	r := (*rtype)(i.p)
+	return r
+}
+
+type funcValue struct {
+	_ uintptr
+	p unsafe.Pointer
+}
+
+func funcPointer(v reflect.Method, ok bool) (unsafe.Pointer, bool) {
+	return (*funcValue)(unsafe.Pointer(&v.Func)).p, ok
+}
+func MethodByName(r reflect.Type, name string) (fn unsafe.Pointer, ok bool) {
+	t := Create(r)
+	if r.Kind() == reflect.Interface {
+		return funcPointer(r.MethodByName(name))
+	}
+	ut := t.uncommon(r)
+	if ut == nil {
+		return nil, false
+	}
+
+	for _, p := range ut.methods() {
+		if t.nameOff(p.name).name() == name {
+			return t.Method(p), true
+		}
+	}
+	return nil, false
+}
+
+func (t *rtype) Method(p method) (fn unsafe.Pointer) {
+	tfn := t.textOff(p.tfn)
+	fn = unsafe.Pointer(&tfn)
+	return
+}
+
+type tflag uint8
+type nameOff int32 // offset to a name
+type typeOff int32 // offset to an *rtype
+type textOff int32 // offset from top of text section
+
+//go:linkname resolveTextOff reflect.resolveTextOff
+func resolveTextOff(rtype unsafe.Pointer, off int32) unsafe.Pointer
+
+func (t *rtype) textOff(off textOff) unsafe.Pointer {
+	return resolveTextOff(unsafe.Pointer(t), int32(off))
+}
+
+//go:linkname resolveNameOff reflect.resolveNameOff
+func resolveNameOff(ptrInModule unsafe.Pointer, off int32) unsafe.Pointer
+
+func (t *rtype) nameOff(off nameOff) name {
+	return name{(*byte)(resolveNameOff(unsafe.Pointer(t), int32(off)))}
+}
+
+const (
+	tflagUncommon tflag = 1 << 0
+)
+
+// uncommonType is present only for defined types or types with methods
+type uncommonType struct {
+	pkgPath nameOff // import path; empty for built-in types like int, string
+	mcount  uint16  // number of methods
+	xcount  uint16  // number of exported methods
+	moff    uint32  // offset from this uncommontype to [mcount]method
+	_       uint32  // unused
+}
+
+// ptrType represents a pointer type.
+type ptrType struct {
+	rtype
+	elem *rtype // pointer element (pointed at) type
+}
+
+// funcType represents a function type.
+type funcType struct {
+	rtype
+	inCount  uint16
+	outCount uint16 // top bit is set if last input parameter is ...
+}
+
+func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
+	return unsafe.Pointer(uintptr(p) + x)
+}
+
+// interfaceType represents an interface type.
+type interfaceType struct {
+	rtype
+	pkgPath name      // import path
+	methods []imethod // sorted by hash
+}
+
+type imethod struct {
+	name nameOff // name of method
+	typ  typeOff // .(*FuncType) underneath
+}
+
+type String struct {
+	Data unsafe.Pointer
+	Len  int
+}
+
+func (t *rtype) uncommon(r reflect.Type) *uncommonType {
+	if t.tflag&tflagUncommon == 0 {
+		return nil
+	}
+	switch r.Kind() {
+	case reflect.Ptr:
+		type u struct {
+			ptrType
+			u uncommonType
+		}
+		return &(*u)(unsafe.Pointer(t)).u
+	case reflect.Func:
+		type u struct {
+			funcType
+			u uncommonType
+		}
+		return &(*u)(unsafe.Pointer(t)).u
+	case reflect.Interface:
+		type u struct {
+			interfaceType
+			u uncommonType
+		}
+		return &(*u)(unsafe.Pointer(t)).u
+	case reflect.Struct:
+		type u struct {
+			interfaceType
+			u uncommonType
+		}
+		return &(*u)(unsafe.Pointer(t)).u
+	default:
+		return nil
+	}
+}
+
+// Method on non-interface type
+type method struct {
+	name nameOff // name of method
+	mtyp typeOff // method type (without receiver)
+	ifn  textOff // fn used in interface call (one-word receiver)
+	tfn  textOff // fn used for normal method call
+}
+
+func (t *uncommonType) methods() []method {
+	if t.mcount == 0 {
+		return nil
+	}
+	return (*[1 << 16]method)(add(unsafe.Pointer(t), uintptr(t.moff), "t.mcount > 0"))[:t.mcount:t.mcount]
+}

--- a/vendor/github.com/agiledragon/gomonkey/v2/jmp_386.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/jmp_386.go
@@ -1,0 +1,13 @@
+package gomonkey
+
+func buildJmpDirective(double uintptr) []byte {
+	d0 := byte(double)
+	d1 := byte(double >> 8)
+	d2 := byte(double >> 16)
+	d3 := byte(double >> 24)
+
+	return []byte{
+		0xBA, d0, d1, d2, d3, // MOV edx, double
+		0xFF, 0x22, // JMP [edx]
+	}
+}

--- a/vendor/github.com/agiledragon/gomonkey/v2/jmp_amd64.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/jmp_amd64.go
@@ -1,0 +1,18 @@
+package gomonkey
+
+func buildJmpDirective(double uintptr) []byte {
+    d0 := byte(double)
+    d1 := byte(double >> 8)
+    d2 := byte(double >> 16)
+    d3 := byte(double >> 24)
+    d4 := byte(double >> 32)
+    d5 := byte(double >> 40)
+    d6 := byte(double >> 48)
+    d7 := byte(double >> 56)
+
+    return []byte{
+        0x48, 0xBA, d0, d1, d2, d3, d4, d5, d6, d7, // MOV rdx, double
+        0xFF, 0x22,     // JMP [rdx]
+    }
+}
+

--- a/vendor/github.com/agiledragon/gomonkey/v2/jmp_arm64.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/jmp_arm64.go
@@ -1,0 +1,37 @@
+//go:build arm64
+// +build arm64
+
+package gomonkey
+
+import "unsafe"
+
+func buildJmpDirective(double uintptr) []byte {
+	res := make([]byte, 0, 24)
+	d0d1 := double & 0xFFFF
+	d2d3 := double >> 16 & 0xFFFF
+	d4d5 := double >> 32 & 0xFFFF
+	d6d7 := double >> 48 & 0xFFFF
+
+	res = append(res, movImm(0b10, 0, d0d1)...)          // MOVZ x26, double[16:0]
+	res = append(res, movImm(0b11, 1, d2d3)...)          // MOVK x26, double[32:16]
+	res = append(res, movImm(0b11, 2, d4d5)...)          // MOVK x26, double[48:32]
+	res = append(res, movImm(0b11, 3, d6d7)...)          // MOVK x26, double[64:48]
+	res = append(res, []byte{0x4A, 0x03, 0x40, 0xF9}...) // LDR x10, [x26]
+	res = append(res, []byte{0x40, 0x01, 0x1F, 0xD6}...) // BR x10
+
+	return res
+}
+
+func movImm(opc, shift int, val uintptr) []byte {
+	var m uint32 = 26          // rd
+	m |= uint32(val) << 5      // imm16
+	m |= uint32(shift&3) << 21 // hw
+	m |= 0b100101 << 23        // const
+	m |= uint32(opc&0x3) << 29 // opc
+	m |= 0b1 << 31             // sf
+
+	res := make([]byte, 4)
+	*(*uint32)(unsafe.Pointer(&res[0])) = m
+
+	return res
+}

--- a/vendor/github.com/agiledragon/gomonkey/v2/jmp_loong64.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/jmp_loong64.go
@@ -1,0 +1,73 @@
+//go:build loong64
+// +build loong64
+
+package gomonkey
+
+import "unsafe"
+
+const (
+	REG_R0  uint32 = 0
+	REG_R29        = 29
+	REG_R30        = 30
+)
+
+const (
+	OP_ORI    uint32 = 0x00E << 22
+	OP_LU12IW        = 0x00A << 25
+	OP_LU32ID        = 0x00B << 25
+	OP_LU52ID        = 0x00C << 22
+	OP_LDD           = 0x0A3 << 22
+	OP_JIRL          = 0x013 << 26
+)
+
+func buildJmpDirective(double uintptr) []byte {
+	res := make([]byte, 0, 24)
+
+	bit11_0 := (double >> 0) & 0xFFF
+	bit31_12 := (double >> 12) & 0xFFFFF
+	bit51_32 := (double >> 32) & 0xFFFFF
+	bit63_52 := (double >> 52) & 0xFFF
+
+	// lu12i.w r29, bit31_12
+	// ori     r29, r29, bit11_0
+	// lu32i.d r29, bit51_32
+	// lu52i.d r29, bit63_52
+	// ld.d,   r30, r29, 0
+	// jirl    r0,  r30, 0
+	res = append(res, wireup_opc(OP_LU12IW, REG_R29, 0, bit31_12)...)
+	res = append(res, wireup_opc(OP_ORI, REG_R29, REG_R29, bit11_0)...)
+	res = append(res, wireup_opc(OP_LU32ID, REG_R29, 0, bit51_32)...)
+	res = append(res, wireup_opc(OP_LU52ID, REG_R29, REG_R29, bit63_52)...)
+	res = append(res, wireup_opc(OP_LDD, REG_R30, REG_R29, 0)...)
+	res = append(res, wireup_opc(OP_JIRL, REG_R0, REG_R30, 0)...)
+
+	return res
+}
+
+func wireup_opc(opc uint32, rd, rj uint32, val uintptr) []byte {
+	var m uint32 = 0
+
+	switch opc {
+	case OP_ORI, OP_LU52ID, OP_LDD:
+		m |= opc
+		m |= (rd & 0x1F) << 0            // rd
+		m |= (rj & 0x1F) << 5            // rj
+		m |= (uint32(val) & 0xFFF) << 10 // si12
+
+	case OP_LU12IW, OP_LU32ID:
+		m |= opc
+		m |= (rd & 0x1F) << 0             // rd
+		m |= (uint32(val) & 0xFFFFF) << 5 // si20
+
+	case OP_JIRL:
+		m |= opc
+		m |= (rd & 0x1F) << 0             // rd
+		m |= (rj & 0x1F) << 5             // rj
+		m |= (uint32(val) & 0xFFFF) << 10 // si16
+	}
+
+	res := make([]byte, 4)
+	*(*uint32)(unsafe.Pointer(&res[0])) = m
+
+	return res
+}

--- a/vendor/github.com/agiledragon/gomonkey/v2/jmp_riscv64.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/jmp_riscv64.go
@@ -1,0 +1,105 @@
+package gomonkey
+
+import (
+	"encoding/binary"
+)
+
+// buildJmpDirective 为 riscv64 架构生成一段跳转指令，
+// 将传入的 64 位地址加载到寄存器 x6（t1）中，
+// 然后执行 JALR x0, 0(x6) 实现无条件跳转。
+func buildJmpDirective(double uintptr) []byte {
+	var res []byte
+	// 将地址转换为 64 位无符号整数
+	d := uint64(double)
+	// 将 64 位地址拆分成若干部分：
+	// imm0: 位 [7:0]
+	// imm1: 位 [19:8] (12 位)
+	// imm2: 位 [31:20] (12 位)
+	// imm3: 位 [43:32] (12 位)
+	// imm4: 位 [63:44] (20 位)
+	imm0 := d & 0xff
+	imm1 := (d >> 8) & 0xfff
+	imm2 := (d >> 20) & 0xfff
+	imm3 := (d >> 32) & 0xfff
+	imm4 := (d >> 44) & 0xfffff
+
+	// 依次生成指令：
+	// 1. LUI x6, imm4  // 将最高 20 位加载到 x6
+	res = append(res, encodeLUI(6, uint32(imm4))...)
+	// 2. ADDI x6, x6, imm3  // 加载接下来的 12 位
+	res = append(res, encodeADDI(6, 6, int32(imm3))...)
+	// 3. SLLI x6, x6, 12   // 左移 12 位
+	res = append(res, encodeSLLI(6, 6, 12)...)
+	// 4. ADDI x6, x6, imm2  // 加载接下来的 12 位
+	res = append(res, encodeADDI(6, 6, int32(imm2))...)
+	// 5. SLLI x6, x6, 12   // 再次左移 12 位
+	res = append(res, encodeSLLI(6, 6, 12)...)
+	// 6. ADDI x6, x6, imm1  // 加载接下来的 12 位
+	res = append(res, encodeADDI(6, 6, int32(imm1))...)
+	// 7. SLLI x6, x6, 8    // 左移 8 位
+	res = append(res, encodeSLLI(6, 6, 8)...)
+	// 8. ORI x6, x6, imm0  // 最后加载最低 8 位
+	res = append(res, encodeORI(6, 6, int32(imm0))...)
+	// 9. JALR x0, 0(x6)    // 跳转到 x6 指定的地址
+	res = append(res, encodeJALR(0, 6, 0)...)
+
+	return res
+}
+
+// 以下辅助函数生成各条指令的机器码，均返回 4 字节小端表示。
+
+// LUI 指令格式：
+// 31          12 11   7 6       0
+// [ imm[31:12] ] [ rd ] [ opcode ]
+// opcode LUI 为 0x37。
+func encodeLUI(rd int, imm20 uint32) []byte {
+	inst := (imm20 << 12) | (uint32(rd) << 7) | 0x37
+	res := make([]byte, 4)
+	binary.LittleEndian.PutUint32(res, inst)
+	return res
+}
+
+// ADDI 指令格式（用于加载 12 位立即数）：
+// 31         20 19   15 14 12 11   7 6       0
+// [ imm[11:0] ] [ rs1 ] [funct3] [ rd ] [ opcode ]
+// opcode ADDI 为 0x13，funct3 为 0。
+func encodeADDI(rd, rs1 int, imm int32) []byte {
+	inst := ((uint32(imm) & 0xfff) << 20) | (uint32(rs1) << 15) | (uint32(rd) << 7) | 0x13
+	res := make([]byte, 4)
+	binary.LittleEndian.PutUint32(res, inst)
+	return res
+}
+
+// SLLI 指令格式：
+// 31      26 25    20 19   15 14 12 11   7 6       0
+// [ 0 ] [ shamt ] [ rs1 ] [funct3] [ rd ] [ opcode ]
+// opcode 为 0x13，funct3 为 1。
+func encodeSLLI(rd, rs1, shamt int) []byte {
+	inst := (uint32(shamt) << 20) | (uint32(rs1) << 15) | (1 << 12) | (uint32(rd) << 7) | 0x13
+	res := make([]byte, 4)
+	binary.LittleEndian.PutUint32(res, inst)
+	return res
+}
+
+// ORI 指令格式：
+// 31         20 19   15 14 12 11   7 6       0
+// [ imm[11:0] ] [ rs1 ] [funct3] [ rd ] [ opcode ]
+// opcode 为 0x13，funct3 为 6。
+func encodeORI(rd, rs1 int, imm int32) []byte {
+	inst := ((uint32(imm) & 0xfff) << 20) | (uint32(rs1) << 15) | (6 << 12) | (uint32(rd) << 7) | 0x13
+	res := make([]byte, 4)
+	binary.LittleEndian.PutUint32(res, inst)
+	return res
+}
+
+// JALR 指令格式：
+// 31         20 19   15 14 12 11   7 6       0
+// [ imm[11:0] ] [ rs1 ] [funct3] [ rd ] [ opcode ]
+// opcode 为 0x67，funct3 为 0。
+// JALR x0, 0(x6) 用于无条件跳转。
+func encodeJALR(rd, rs1 int, imm int32) []byte {
+	inst := ((uint32(imm) & 0xfff) << 20) | (uint32(rs1) << 15) | (uint32(rd) << 7) | 0x67
+	res := make([]byte, 4)
+	binary.LittleEndian.PutUint32(res, inst)
+	return res
+}

--- a/vendor/github.com/agiledragon/gomonkey/v2/modify_binary_darwin.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/modify_binary_darwin.go
@@ -1,0 +1,24 @@
+package gomonkey
+
+import (
+	"fmt"
+	"reflect"
+	"syscall"
+	"unsafe"
+)
+
+func PtrOf(val []byte) uintptr {
+	return (*reflect.SliceHeader)(unsafe.Pointer(&val)).Data
+}
+
+func modifyBinary(target uintptr, bytes []byte) {
+	targetPage := pageStart(target)
+	res := write(target, PtrOf(bytes), len(bytes), targetPage, syscall.Getpagesize(), syscall.PROT_READ|syscall.PROT_EXEC)
+	if res != 0 {
+		panic(fmt.Errorf("failed to write memory, code %v", res))
+	}
+}
+
+//go:cgo_import_dynamic mach_task_self mach_task_self "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic mach_vm_protect mach_vm_protect "/usr/lib/libSystem.B.dylib"
+func write(target, data uintptr, len int, page uintptr, pageSize, oriProt int) int

--- a/vendor/github.com/agiledragon/gomonkey/v2/modify_binary_linux.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/modify_binary_linux.go
@@ -1,0 +1,27 @@
+package gomonkey
+
+import "syscall"
+
+func modifyBinary(target uintptr, bytes []byte) {
+	function := entryAddress(target, len(bytes))
+	err := mprotectCrossPage(target, len(bytes), syscall.PROT_READ|syscall.PROT_WRITE|syscall.PROT_EXEC)
+	if err != nil {
+		panic(err)
+	}
+	copy(function, bytes)
+	err = mprotectCrossPage(target, len(bytes), syscall.PROT_READ|syscall.PROT_EXEC)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func mprotectCrossPage(addr uintptr, length int, prot int) error {
+	pageSize := syscall.Getpagesize()
+	for p := pageStart(addr); p < addr+uintptr(length); p += uintptr(pageSize) {
+		page := entryAddress(p, pageSize)
+		if err := syscall.Mprotect(page, prot); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/agiledragon/gomonkey/v2/modify_binary_windows.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/modify_binary_windows.go
@@ -1,0 +1,25 @@
+package gomonkey
+
+import (
+    "syscall"
+    "unsafe"
+)
+
+func modifyBinary(target uintptr, bytes []byte) {
+    function := entryAddress(target, len(bytes))
+    
+    proc := syscall.NewLazyDLL("kernel32.dll").NewProc("VirtualProtect")
+    const PROT_READ_WRITE = 0x40
+    var old uint32
+    result, _, _ := proc.Call(target, uintptr(len(bytes)), uintptr(PROT_READ_WRITE), uintptr(unsafe.Pointer(&old)))
+    if result == 0 {
+        panic(result)
+    }
+    copy(function, bytes)
+    
+    var ignore uint32
+    result, _, _ = proc.Call(target, uintptr(len(bytes)), uintptr(old), uintptr(unsafe.Pointer(&ignore)))
+    if result == 0 {
+        panic(result)
+    }
+}

--- a/vendor/github.com/agiledragon/gomonkey/v2/patch.go
+++ b/vendor/github.com/agiledragon/gomonkey/v2/patch.go
@@ -1,0 +1,391 @@
+package gomonkey
+
+import (
+	"fmt"
+	"reflect"
+	"syscall"
+	"unsafe"
+
+	"github.com/agiledragon/gomonkey/v2/creflect"
+)
+
+type Patches struct {
+	originals    map[uintptr][]byte
+	targets      map[uintptr]uintptr
+	values       map[reflect.Value]reflect.Value
+	valueHolders map[reflect.Value]reflect.Value
+}
+
+type Params []interface{}
+type OutputCell struct {
+	Values Params
+	Times  int
+}
+
+func ApplyFunc(target, double interface{}) *Patches {
+	return create().ApplyFunc(target, double)
+}
+
+func ApplyMethod(target interface{}, methodName string, double interface{}) *Patches {
+	return create().ApplyMethod(target, methodName, double)
+}
+
+func ApplyMethodFunc(target interface{}, methodName string, doubleFunc interface{}) *Patches {
+	return create().ApplyMethodFunc(target, methodName, doubleFunc)
+}
+
+func ApplyPrivateMethod(target interface{}, methodName string, double interface{}) *Patches {
+	return create().ApplyPrivateMethod(target, methodName, double)
+}
+
+func ApplyGlobalVar(target, double interface{}) *Patches {
+	return create().ApplyGlobalVar(target, double)
+}
+
+func ApplyFuncVar(target, double interface{}) *Patches {
+	return create().ApplyFuncVar(target, double)
+}
+
+func ApplyFuncSeq(target interface{}, outputs []OutputCell) *Patches {
+	return create().ApplyFuncSeq(target, outputs)
+}
+
+func ApplyMethodSeq(target interface{}, methodName string, outputs []OutputCell) *Patches {
+	return create().ApplyMethodSeq(target, methodName, outputs)
+}
+
+func ApplyFuncVarSeq(target interface{}, outputs []OutputCell) *Patches {
+	return create().ApplyFuncVarSeq(target, outputs)
+}
+
+func ApplyFuncReturn(target interface{}, output ...interface{}) *Patches {
+	return create().ApplyFuncReturn(target, output...)
+}
+
+func ApplyMethodReturn(target interface{}, methodName string, output ...interface{}) *Patches {
+	return create().ApplyMethodReturn(target, methodName, output...)
+}
+
+func ApplyFuncVarReturn(target interface{}, output ...interface{}) *Patches {
+	return create().ApplyFuncVarReturn(target, output...)
+}
+
+func create() *Patches {
+	return &Patches{originals: make(map[uintptr][]byte), targets: map[uintptr]uintptr{},
+		values: make(map[reflect.Value]reflect.Value), valueHolders: make(map[reflect.Value]reflect.Value)}
+}
+
+func NewPatches() *Patches {
+	return create()
+}
+
+func (this *Patches) Origin(fn func()) {
+	for target, bytes := range this.originals {
+		modifyBinary(target, bytes)
+	}
+	fn()
+	for target, targetPtr := range this.targets {
+		code := buildJmpDirective(targetPtr)
+		modifyBinary(target, code)
+	}
+}
+
+func (this *Patches) ApplyFunc(target, double interface{}) *Patches {
+	t := reflect.ValueOf(target)
+	d := reflect.ValueOf(double)
+	return this.ApplyCore(t, d)
+}
+
+func (this *Patches) ApplyMethod(target interface{}, methodName string, double interface{}) *Patches {
+	m, ok := castRType(target).MethodByName(methodName)
+	if !ok {
+		panic("retrieve method by name failed")
+	}
+	d := reflect.ValueOf(double)
+	return this.ApplyCore(m.Func, d)
+}
+
+func (this *Patches) ApplyMethodFunc(target interface{}, methodName string, doubleFunc interface{}) *Patches {
+	m, ok := castRType(target).MethodByName(methodName)
+	if !ok {
+		panic("retrieve method by name failed")
+	}
+	d := funcToMethod(m.Type, doubleFunc)
+	return this.ApplyCore(m.Func, d)
+}
+
+func (this *Patches) ApplyPrivateMethod(target interface{}, methodName string, double interface{}) *Patches {
+	m, ok := creflect.MethodByName(castRType(target), methodName)
+	if !ok {
+		panic("retrieve method by name failed")
+	}
+	d := reflect.ValueOf(double)
+	return this.ApplyCoreOnlyForPrivateMethod(m, d)
+}
+
+func (this *Patches) ApplyGlobalVar(target, double interface{}) *Patches {
+	t := reflect.ValueOf(target)
+	if t.Type().Kind() != reflect.Ptr {
+		panic("target is not a pointer")
+	}
+
+	this.values[t] = reflect.ValueOf(t.Elem().Interface())
+	d := reflect.ValueOf(double)
+	t.Elem().Set(d)
+	return this
+}
+
+func (this *Patches) ApplyFuncVar(target, double interface{}) *Patches {
+	t := reflect.ValueOf(target)
+	d := reflect.ValueOf(double)
+	if t.Type().Kind() != reflect.Ptr {
+		panic("target is not a pointer")
+	}
+	this.check(t.Elem(), d)
+	return this.ApplyGlobalVar(target, double)
+}
+
+func (this *Patches) ApplyFuncSeq(target interface{}, outputs []OutputCell) *Patches {
+	funcType := reflect.TypeOf(target)
+	t := reflect.ValueOf(target)
+	d := getDoubleFunc(funcType, outputs)
+	return this.ApplyCore(t, d)
+}
+
+func (this *Patches) ApplyMethodSeq(target interface{}, methodName string, outputs []OutputCell) *Patches {
+	m, ok := castRType(target).MethodByName(methodName)
+	if !ok {
+		panic("retrieve method by name failed")
+	}
+	d := getDoubleFunc(m.Type, outputs)
+	return this.ApplyCore(m.Func, d)
+}
+
+func (this *Patches) ApplyFuncVarSeq(target interface{}, outputs []OutputCell) *Patches {
+	t := reflect.ValueOf(target)
+	if t.Type().Kind() != reflect.Ptr {
+		panic("target is not a pointer")
+	}
+	if t.Elem().Kind() != reflect.Func {
+		panic("target is not a func")
+	}
+
+	funcType := reflect.TypeOf(target).Elem()
+	double := getDoubleFunc(funcType, outputs).Interface()
+	return this.ApplyGlobalVar(target, double)
+}
+
+func (this *Patches) ApplyFuncReturn(target interface{}, returns ...interface{}) *Patches {
+	funcType := reflect.TypeOf(target)
+	t := reflect.ValueOf(target)
+	outputs := []OutputCell{{Values: returns, Times: -1}}
+	d := getDoubleFunc(funcType, outputs)
+	return this.ApplyCore(t, d)
+}
+
+func (this *Patches) ApplyMethodReturn(target interface{}, methodName string, returns ...interface{}) *Patches {
+	m, ok := reflect.TypeOf(target).MethodByName(methodName)
+	if !ok {
+		panic("retrieve method by name failed")
+	}
+
+	outputs := []OutputCell{{Values: returns, Times: -1}}
+	d := getDoubleFunc(m.Type, outputs)
+	return this.ApplyCore(m.Func, d)
+}
+
+func (this *Patches) ApplyFuncVarReturn(target interface{}, returns ...interface{}) *Patches {
+	t := reflect.ValueOf(target)
+	if t.Type().Kind() != reflect.Ptr {
+		panic("target is not a pointer")
+	}
+	if t.Elem().Kind() != reflect.Func {
+		panic("target is not a func")
+	}
+
+	funcType := reflect.TypeOf(target).Elem()
+	outputs := []OutputCell{{Values: returns, Times: -1}}
+	double := getDoubleFunc(funcType, outputs).Interface()
+	return this.ApplyGlobalVar(target, double)
+}
+
+func (this *Patches) Reset() {
+	for target, bytes := range this.originals {
+		modifyBinary(target, bytes)
+		delete(this.originals, target)
+	}
+
+	for target, variable := range this.values {
+		target.Elem().Set(variable)
+	}
+}
+
+func (this *Patches) ApplyCore(target, double reflect.Value) *Patches {
+	this.check(target, double)
+	assTarget := *(*uintptr)(getPointer(target))
+	original := replace(assTarget, uintptr(getPointer(double)))
+	if _, ok := this.originals[assTarget]; !ok {
+		this.originals[assTarget] = original
+	}
+	this.targets[assTarget] = uintptr(getPointer(double))
+	this.valueHolders[double] = double
+	return this
+}
+
+func (this *Patches) ApplyCoreOnlyForPrivateMethod(target unsafe.Pointer, double reflect.Value) *Patches {
+	if double.Kind() != reflect.Func {
+		panic("double is not a func")
+	}
+	assTarget := *(*uintptr)(target)
+	original := replace(assTarget, uintptr(getPointer(double)))
+	if _, ok := this.originals[assTarget]; !ok {
+		this.originals[assTarget] = original
+	}
+	this.targets[assTarget] = uintptr(getPointer(double))
+	this.valueHolders[double] = double
+	return this
+}
+
+func (this *Patches) check(target, double reflect.Value) {
+	if target.Kind() != reflect.Func {
+		panic("target is not a func")
+	}
+
+	if double.Kind() != reflect.Func {
+		panic("double is not a func")
+	}
+
+	targetType := target.Type()
+	doubleType := double.Type()
+
+	if targetType.NumIn() < doubleType.NumIn() ||
+		targetType.NumOut() != doubleType.NumOut() ||
+		(targetType.NumIn() == doubleType.NumIn() && targetType.IsVariadic() != doubleType.IsVariadic()) {
+		panic(fmt.Sprintf("target type(%s) and double type(%s) are different", target.Type(), double.Type()))
+	}
+
+	for i, size := 0, doubleType.NumIn(); i < size; i++ {
+		targetIn := targetType.In(i)
+		doubleIn := doubleType.In(i)
+
+		if targetIn.AssignableTo(doubleIn) {
+			continue
+		}
+
+		panic(fmt.Sprintf("target type(%s) and double type(%s) are different", target.Type(), double.Type()))
+	}
+
+	for i, size := 0, doubleType.NumOut(); i < size; i++ {
+		targetOut := targetType.Out(i)
+		doubleOut := doubleType.Out(i)
+
+		if targetOut.AssignableTo(doubleOut) {
+			continue
+		}
+
+		panic(fmt.Sprintf("target type(%s) and double type(%s) are different", target.Type(), double.Type()))
+	}
+}
+
+func replace(target, double uintptr) []byte {
+	code := buildJmpDirective(double)
+	bytes := entryAddress(target, len(code))
+	original := make([]byte, len(bytes))
+	copy(original, bytes)
+	modifyBinary(target, code)
+	return original
+}
+
+func getDoubleFunc(funcType reflect.Type, outputs []OutputCell) reflect.Value {
+	if funcType.NumOut() != len(outputs[0].Values) {
+		panic(fmt.Sprintf("func type has %v return values, but only %v values provided as double",
+			funcType.NumOut(), len(outputs[0].Values)))
+	}
+
+	needReturn := false
+	slice := make([]Params, 0)
+	for _, output := range outputs {
+		if output.Times == -1 {
+			needReturn = true
+			slice = []Params{output.Values}
+			break
+		}
+		t := 0
+		if output.Times <= 1 {
+			t = 1
+		} else {
+			t = output.Times
+		}
+		for j := 0; j < t; j++ {
+			slice = append(slice, output.Values)
+		}
+	}
+
+	i := 0
+	lenOutputs := len(slice)
+	return reflect.MakeFunc(funcType, func(_ []reflect.Value) []reflect.Value {
+		if needReturn {
+			return GetResultValues(funcType, slice[0]...)
+		}
+		if i < lenOutputs {
+			i++
+			return GetResultValues(funcType, slice[i-1]...)
+		}
+		panic("double seq is less than call seq")
+	})
+}
+
+func GetResultValues(funcType reflect.Type, results ...interface{}) []reflect.Value {
+	var resultValues []reflect.Value
+	for i, r := range results {
+		var resultValue reflect.Value
+		if r == nil {
+			resultValue = reflect.Zero(funcType.Out(i))
+		} else {
+			v := reflect.New(funcType.Out(i))
+			v.Elem().Set(reflect.ValueOf(r))
+			resultValue = v.Elem()
+		}
+		resultValues = append(resultValues, resultValue)
+	}
+	return resultValues
+}
+
+type funcValue struct {
+	_ uintptr
+	p unsafe.Pointer
+}
+
+func getPointer(v reflect.Value) unsafe.Pointer {
+	return (*funcValue)(unsafe.Pointer(&v)).p
+}
+
+func entryAddress(p uintptr, l int) []byte {
+	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{Data: p, Len: l, Cap: l}))
+}
+
+func pageStart(ptr uintptr) uintptr {
+	return ptr & ^(uintptr(syscall.Getpagesize() - 1))
+}
+
+func funcToMethod(funcType reflect.Type, doubleFunc interface{}) reflect.Value {
+	rf := reflect.TypeOf(doubleFunc)
+	if rf.Kind() != reflect.Func {
+		panic("doubleFunc is not a func")
+	}
+	vf := reflect.ValueOf(doubleFunc)
+	return reflect.MakeFunc(funcType, func(in []reflect.Value) []reflect.Value {
+		if funcType.IsVariadic() {
+			return vf.CallSlice(in[1:])
+		} else {
+			return vf.Call(in[1:])
+		}
+	})
+}
+
+func castRType(val interface{}) reflect.Type {
+	if rTypeVal, ok := val.(reflect.Type); ok {
+		return rTypeVal
+	}
+	return reflect.TypeOf(val)
+}

--- a/vendor/github.com/agiledragon/gomonkey/v2/ut.sh
+++ b/vendor/github.com/agiledragon/gomonkey/v2/ut.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+echo "" > coverage.txt
+
+for d in $(go list ./test/...  | grep -v test/fake); do
+    echo "--------Run test package: $d"
+    GO111MODULE=on go test -gcflags="all=-N -l" -v -coverprofile=profile.out -coverpkg=./... -covermode=atomic $d
+    echo "--------Finish test package: $d"
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done

--- a/vendor/github.com/agiledragon/gomonkey/v2/write_darwin_amd64.s
+++ b/vendor/github.com/agiledragon/gomonkey/v2/write_darwin_amd64.s
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "textflag.h"
+
+#define NOP8 BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90;
+#define NOP64 NOP8; NOP8; NOP8; NOP8; NOP8; NOP8; NOP8; NOP8;
+#define NOP512 NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64;
+#define NOP4096 NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512;
+
+#define protRW $(0x1|0x2|0x10)
+#define mProtect $(0x2000000+74)
+
+TEXT ·write(SB),NOSPLIT,$24
+    JMP START
+    NOP4096
+START:
+    MOVQ    mProtect, AX
+    MOVQ    page+24(FP), DI
+    MOVQ    pageSize+32(FP), SI
+    MOVQ    protRW, DX
+    SYSCALL
+    CMPQ    AX, $0
+    JZ      PROTECT_OK
+    CALL    mach_task_self(SB)
+    MOVQ    AX, DI
+    MOVQ    target+0(FP), SI
+    MOVQ    len+16(FP), DX
+    MOVQ    $0, CX
+    MOVQ    protRW, R8
+    CALL    mach_vm_protect(SB)
+    CMPQ    AX, $0
+    JNZ     RETURN
+PROTECT_OK:
+    MOVQ    target+0(FP), DI
+    MOVQ    data+8(FP), SI
+    MOVQ    len+16(FP), CX
+    MOVQ    DI, to-24(SP)
+    MOVQ    SI, from-16(SP)
+    MOVQ    CX, n-8(SP)
+    CALL    runtime·memmove(SB)
+    MOVQ    mProtect, AX
+    MOVQ    page+24(FP), DI
+    MOVQ    pageSize+32(FP), SI
+    MOVQ    oriProt+40(FP), DX
+    SYSCALL
+    JMP     RETURN
+    NOP4096
+RETURN:
+    MOVQ AX, ret+48(FP)
+    RET

--- a/vendor/github.com/agiledragon/gomonkey/v2/write_darwin_arm64.s
+++ b/vendor/github.com/agiledragon/gomonkey/v2/write_darwin_arm64.s
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "textflag.h"
+
+#define NOP64 WORD $0x1f2003d5; WORD $0x1f2003d5;
+#define NOP512 NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64;
+#define NOP4096 NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512;
+#define NOP16384 NOP4096; NOP4096; NOP4096; NOP4096; NOP4096; NOP4096; NOP4096; NOP4096;
+
+#define protRW $(0x1|0x2|0x10)
+#define mProtect $(0x2000000+74)
+
+TEXT ·write(SB),NOSPLIT,$24
+    B START
+    NOP16384
+START:
+    MOVD    mProtect, R16
+    MOVD    page+24(FP), R0
+    MOVD    pageSize+32(FP), R1
+    MOVD    protRW, R2
+    SVC     $0x80
+    CMP     $0, R0
+    BEQ     PROTECT_OK
+    CALL    mach_task_self(SB)
+    MOVD    target+0(FP), R1
+    MOVD    len+16(FP), R2
+    MOVD    $0, R3
+    MOVD    protRW, R4
+    CALL    mach_vm_protect(SB)
+    CMP     $0, R0
+    BNE     RETURN
+PROTECT_OK:
+    MOVD    target+0(FP), R0
+    MOVD    data+8(FP), R1
+    MOVD    len+16(FP), R2
+    MOVD    R0, to-24(SP)
+    MOVD    R1, from-16(SP)
+    MOVD    R2, n-8(SP)
+    CALL    runtime·memmove(SB)
+    MOVD    mProtect, R16
+    MOVD    page+24(FP), R0
+    MOVD    pageSize+32(FP), R1
+    MOVD    oriProt+40(FP), R2
+    SVC     $0x80
+    B       RETURN
+    NOP16384
+RETURN:
+    MOVD R0, ret+48(FP)
+    RET

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,7 @@
+# github.com/agiledragon/gomonkey/v2 v2.13.0
+## explicit; go 1.14
+github.com/agiledragon/gomonkey/v2
+github.com/agiledragon/gomonkey/v2/creflect
 # github.com/beorn7/perks v1.0.1
 ## explicit; go 1.11
 github.com/beorn7/perks/quantile


### PR DESCRIPTION
这个 PR 先实现了会话池（连接缓存）和会话的框架，以及 SSH 和 Redfish 对于会话操作客户端的实现。详细设计可以看 PR 文件中的 doc/design/session-pool/README.md

后续分别将 SSH 使用 client 和 Redfish 使用 client 的地方修改为使用 SessionPool。